### PR TITLE
Oskari 2.0

### DIFF
--- a/nlsfi-projections/pom.xml
+++ b/nlsfi-projections/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>nlsfi-projections</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
     <name>Oskari wrapper for projection libs usable in NSLFI applications</name>
 
@@ -19,8 +19,8 @@
         <dependency>
             <groupId>org.oskari</groupId>
             <artifactId>service-map</artifactId>
-            <!-- Any version after 1.40.0  -->
-            <version>[2.0.0-SNAPSHOT,)</version>
+            <!-- Any version after 2.0.0  -->
+            <version>[2.0.0,)</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/nlsfi-projections/pom.xml
+++ b/nlsfi-projections/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>nlsfi-projections</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Oskari wrapper for projection libs usable in NSLFI applications</name>
 
@@ -17,10 +17,10 @@
             <version>2012.0.0</version>
         </dependency>
         <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-map</artifactId>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-map</artifactId>
             <!-- Any version after 1.40.0  -->
-            <version>[1.40.0,)</version>
+            <version>[2.0.0-SNAPSHOT,)</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -35,12 +35,12 @@
         <repository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/releases/</url>
+            <url>https://oskari.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
             <id>oskari_org_snapshot</id>
             <name>Oskari.org snapshot repository</name>
-            <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
+            <url>https://oskari.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -49,12 +49,12 @@
         <repository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/releases/</url>
+            <url>https://oskari.org/nexus/content/repositories/releases/</url>
         </repository>
         <snapshotRepository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
+            <url>https://oskari.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 </project>

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -13,9 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <!-- Any version after 1.52.0 -->
-        <oskari.version>[1.55.0-SNAPSHOT,)</oskari.version>
+        <oskari.version>[2.0.0-SNAPSHOT,)</oskari.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
-        <geotools.version>22.1</geotools.version>
+        <geotools.version>23.2</geotools.version>
         <javax.xml.version>1.0</javax.xml.version>
         <vecmath.version>1.5.2</vecmath.version>
         <xmlunit.version>1.6</xmlunit.version>
@@ -159,38 +159,9 @@
             <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>http://repo.maven.apache.org/maven2</url>
-            <layout>default</layout>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>maven2-repository.dev.java.net</id>
-            <name>Java.net repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>thecentral</id>
-            <name>The Central repository</name>
-            <url>http://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
             <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-        <repository>
-            <id>geosolutions</id>
-            <name>Geo-solutions Maven Repository</name>
-            <url>http://maven.geo-solutions.it</url>
-        </repository>
-        <repository>
-            <id>boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>http://repo.boundlessgeo.com/main/</url>
+            <name>OSGeo repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
     </repositories>
     <distributionManagement>

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>3.3</version>
+    <version>3.4</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <!-- Any version after 1.52.0 -->
-        <oskari.version>[1.52.0,)</oskari.version>
+        <oskari.version>[1.54.1,)</oskari.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
         <geotools.version>19.2</geotools.version>
         <javax.xml.version>1.0</javax.xml.version>
@@ -197,12 +197,12 @@
         <repository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/releases/</url>
+            <url>https://oskari.org/nexus/content/repositories/releases/</url>
         </repository>
         <snapshotRepository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
+            <url>https://oskari.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -220,7 +220,5 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
-
 
 </project>

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>3.4-SNAPSHOT</version>
+    <version>3.4</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <!-- Any version after 1.52.0 -->
-        <oskari.version>[2.0.0-SNAPSHOT,)</oskari.version>
+        <oskari.version>[2.0.0,)</oskari.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
         <geotools.version>23.2</geotools.version>
         <javax.xml.version>1.0</javax.xml.version>

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>3.4</version>
+    <version>3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 
@@ -13,12 +13,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
         <!-- Any version after 1.52.0 -->
-        <oskari.version>[1.54.1,)</oskari.version>
+        <oskari.version>[1.55.0-SNAPSHOT,)</oskari.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
-        <geotools.version>19.2</geotools.version>
+        <geotools.version>22.1</geotools.version>
         <javax.xml.version>1.0</javax.xml.version>
         <vecmath.version>1.5.2</vecmath.version>
-        <xmlunit.version>1.5</xmlunit.version>
+        <xmlunit.version>1.6</xmlunit.version>
         <xmlbeans.version>2.6.0</xmlbeans.version>
     </properties>
 

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -119,11 +119,6 @@
             <version>${geotools.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jsr173</artifactId>
-            <version>${javax.xml.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
             <version>${vecmath.version}</version>

--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
@@ -36,7 +36,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -49,7 +49,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <failOnError>false</failOnError>
                 </configuration>
@@ -65,11 +65,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.5.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.2.0</version>
             </plugin>
             <plugin>
                 <!-- explicitly define maven-deploy-plugin after other to 
@@ -91,19 +91,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-search</artifactId>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-search</artifactId>
             <version>${oskari.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fi.nls.oskari.service</groupId>
-            <artifactId>oskari-control-base</artifactId>
+            <groupId>org.oskari</groupId>
+            <artifactId>control-base</artifactId>
             <version>${oskari.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fi.nls.oskari</groupId>
+            <groupId>org.oskari</groupId>
             <artifactId>shared-test-resources</artifactId>
             <version>${oskari.version}</version>
             <scope>test</scope>
@@ -129,29 +129,18 @@
             <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlbeans</groupId>
-            <artifactId>xmlbeans</artifactId>
-            <version>${xmlbeans.version}</version>
-        </dependency>
     </dependencies>
 
     <repositories>
         <repository>
             <id>oskari_org</id>
             <name>Oskari.org repository</name>
-            <url>http://oskari.org/nexus/content/repositories/releases/</url>
+            <url>https://oskari.org/nexus/content/repositories/releases/</url>
         </repository>
         <repository>
             <id>oskari_org_snapshot</id>
             <name>Oskari.org snapshot repository</name>
-            <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
+            <url>https://oskari.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>osgeo</id>

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
@@ -37,7 +37,7 @@ public class AddressParamHandler extends ParamHandler {
             log.debug("Got multiple coordinates for address", coordinates);
             // not found or multiple found -> open search plugin with param value
             final JSONObject config = getBundleConfig(params.getConfig(), ViewModifier.BUNDLE_MAPFULL);
-            final JSONObject searchplugin = MapfullHandler.getPlugin(MapfullHandler.PLUGIN_SEARCH, config);
+            final JSONObject searchplugin = MapfullHandler.getPlugin("Oskari.mapframework.bundle.mapmodule.plugin.SearchPlugin", config);
             if(searchplugin != null) {
                 log.debug("Modifying search plugin config", searchplugin);
                 // get existing config or initialize new node

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/ktjkiiwfs/KTJkiiWFSSearchChannelImpl.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/ktjkiiwfs/KTJkiiWFSSearchChannelImpl.java
@@ -1,12 +1,12 @@
 package fi.nls.oskari.search.ktjkiiwfs;
 
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.Point;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.search.channel.ConnectionProvider;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.XmlHelper;
-import org.geotools.GML;
+import org.geotools.wfs.GML;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.ReferencedEnvelope;

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/ELFGeoLocatorParser.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/ELFGeoLocatorParser.java
@@ -111,8 +111,8 @@ public class ELFGeoLocatorParser {
             InputStream xml = new ByteArrayInputStream(outputStream.toByteArray());
 
             //create the parser with the gml 3.0 configuration
-            org.geotools.xml.Configuration configuration = new org.geotools.gml3.GMLConfiguration();
-            org.geotools.xml.Parser parser = new org.geotools.xml.Parser(configuration);
+            org.geotools.xsd.Configuration configuration = new org.geotools.gml3.GMLConfiguration();
+            org.geotools.xsd.Parser parser = new org.geotools.xsd.Parser(configuration);
             parser.setValidating(false);
             parser.setFailOnValidationError(false);
             parser.setStrict(false);
@@ -120,7 +120,7 @@ public class ELFGeoLocatorParser {
 
 
             //parse featurecollection
-            FeatureCollection<SimpleFeatureType, SimpleFeature> fc = null;
+            FeatureCollection<SimpleFeatureType, SimpleFeature> fc;
             try {
                 Object obj = parser.parse(xml);
                 if (obj instanceof Map) {
@@ -167,8 +167,8 @@ public class ELFGeoLocatorParser {
                     log.debug("Bounds:", f.getBounds());
                 }
                 */
-                if (feature.getDefaultGeometry() instanceof com.vividsolutions.jts.geom.Point) {
-                    com.vividsolutions.jts.geom.Point point = (com.vividsolutions.jts.geom.Point) feature.getDefaultGeometry();
+                if (feature.getDefaultGeometry() instanceof org.locationtech.jts.geom.Point) {
+                    org.locationtech.jts.geom.Point point = (org.locationtech.jts.geom.Point) feature.getDefaultGeometry();
                     log.debug("Original coordinates - x:", point.getX(), "y:", point.getY());
 
                     Point p2 = null;

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/ELFGeoLocatorQueryHelper.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/ELFGeoLocatorQueryHelper.java
@@ -9,8 +9,8 @@ package fi.nls.oskari.search.util;
 
 import fi.nls.oskari.service.ServiceRuntimeException;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.xml.Configuration;
-import org.geotools.xml.Encoder;
+import org.geotools.xsd.Configuration;
+import org.geotools.xsd.Encoder;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.PropertyIsEqualTo;

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/util/NLSNearestFeatureParser.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/util/NLSNearestFeatureParser.java
@@ -84,8 +84,8 @@ public class NLSNearestFeatureParser {
             InputStream xml = new ByteArrayInputStream(outputStream.toByteArray());
 
             //create the parser with the gml 3.0 configuration
-            org.geotools.xml.Configuration configuration = new org.geotools.gml3.GMLConfiguration();
-            org.geotools.xml.Parser parser = new org.geotools.xml.Parser(configuration);
+            org.geotools.xsd.Configuration configuration = new org.geotools.gml3.GMLConfiguration();
+            org.geotools.xsd.Parser parser = new org.geotools.xsd.Parser(configuration);
             parser.setValidating(false);
             parser.setFailOnValidationError(false);
             parser.setStrict(false);

--- a/service-search-nls/src/test/java/fi/nls/oskari/control/metadata/GetMetadataSearchOptionsHandlerTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/control/metadata/GetMetadataSearchOptionsHandlerTest.java
@@ -1,7 +1,7 @@
 package fi.nls.oskari.control.metadata;
 
-import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupService;
-import fi.mml.map.mapwindow.service.db.OskariMapLayerGroupServiceIbatisImpl;
+import org.oskari.service.maplayer.OskariMapLayerGroupService;
+import org.oskari.service.maplayer.OskariMapLayerGroupServiceMybatisImpl;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.search.channel.MetadataCatalogueChannelSearchService;
 import fi.nls.oskari.util.IOHelper;
@@ -53,13 +53,13 @@ public class GetMetadataSearchOptionsHandlerTest extends JSONActionRouteTest {
     }
 
     private void mockInternalServices() throws Exception {
-        final OskariMapLayerGroupService service = mock(OskariMapLayerGroupServiceIbatisImpl.class);
+        final OskariMapLayerGroupService service = mock(OskariMapLayerGroupServiceMybatisImpl.class);
         doReturn(Collections.emptyList()).when(service).findAll();
 
 
         // return mocked service if a new one is created
         // classes doing this must be listed in PrepareForTest annotation
-        PowerMockito.whenNew(OskariMapLayerGroupServiceIbatisImpl.class).withNoArguments().
+        PowerMockito.whenNew(OskariMapLayerGroupServiceMybatisImpl.class).withNoArguments().
                 thenAnswer(new Answer<Object>() {
                     public Object answer(InvocationOnMock invocation) throws Throwable {
                         return service;

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/channel/ELFGeoLocatorSearchChannelTest.java
@@ -1,28 +1,18 @@
 package fi.nls.oskari.search.channel;
 
 import fi.mml.portti.service.search.SearchCriteria;
-import fi.nls.oskari.search.util.ELFGeoLocatorCountries;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.filter.FilterTransformer;
-import org.geotools.filter.Filters;
-import org.geotools.xml.Configuration;
-import org.geotools.xml.Encoder;
+
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.opengis.filter.Filter;
-import org.opengis.filter.FilterFactory2;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.Locale;
 
 import static org.junit.Assert.assertTrue;
 

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-finland.xml
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-finland.xml
@@ -1,11 +1,11 @@
 <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112" xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
     <fes:And>
-        <fes:PropertyIsEqualTo matchCase="true">
+        <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
             <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
             </fes:ValueReference>
             <fes:Literal>National Land Survey of Finland</fes:Literal>
         </fes:PropertyIsEqualTo>
-        <fes:PropertyIsEqualTo matchCase="false">
+        <fes:PropertyIsEqualTo matchAction="Any" matchCase="false">
             <fes:ValueReference>
                 iso19112:alternativeGeographicIdentifiers/iso19112:alternativeGeographicIdentifier/iso19112:name
             </fes:ValueReference>

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-no-input-fi.xml
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-no-input-fi.xml
@@ -1,5 +1,5 @@
 <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112" xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
-    <fes:PropertyIsEqualTo matchCase="true">
+    <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
         <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
         </fes:ValueReference>
         <fes:Literal>National Land Survey of Finland</fes:Literal>

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-no-input-no.xml
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-no-input-no.xml
@@ -1,11 +1,11 @@
 <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112" xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
 <fes:Or>
-    <fes:PropertyIsEqualTo matchCase="true">
+    <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
         <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
         </fes:ValueReference>
         <fes:Literal>Norway polar - GN</fes:Literal>
     </fes:PropertyIsEqualTo>
-    <fes:PropertyIsEqualTo matchCase="true">
+    <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
         <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
         </fes:ValueReference>
         <fes:Literal>Norway - GN</fes:Literal>

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-norway.xml
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-norway.xml
@@ -1,18 +1,19 @@
-<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112" xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112"
+            xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
     <fes:And>
-        <fes:PropertyIsEqualTo matchCase="false">
+        <fes:PropertyIsEqualTo matchAction="Any" matchCase="false">
             <fes:ValueReference>
                 iso19112:alternativeGeographicIdentifiers/iso19112:alternativeGeographicIdentifier/iso19112:name
             </fes:ValueReference>
             <fes:Literal>asdf</fes:Literal>
         </fes:PropertyIsEqualTo>
         <fes:Or>
-            <fes:PropertyIsEqualTo matchCase="true">
+            <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
                 <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
                 </fes:ValueReference>
                 <fes:Literal>Norway polar - GN</fes:Literal>
             </fes:PropertyIsEqualTo>
-            <fes:PropertyIsEqualTo matchCase="true">
+            <fes:PropertyIsEqualTo matchAction="Any" matchCase="true">
                 <fes:ValueReference>iso19112:administrator/gmdsf1:CI_ResponsibleParty/gmdsf1:organizationName
                 </fes:ValueReference>
                 <fes:Literal>Norway - GN</fes:Literal>

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-user-input-only.xml
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/util/geolocator-admin-filter-expected-user-input-only.xml
@@ -1,5 +1,5 @@
 <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0" xmlns:iso19112="http://www.isotc211.org/19112" xmlns:gmdsf1="http://www.isotc211.org/2005/gmdsf1">
-    <fes:PropertyIsEqualTo matchCase="false">
+    <fes:PropertyIsEqualTo matchAction="Any" matchCase="false">
         <fes:ValueReference>
             iso19112:alternativeGeographicIdentifiers/iso19112:alternativeGeographicIdentifier/iso19112:name
         </fes:ValueReference>


### PR DESCRIPTION
Versions 1.2 for nlsfi-projections and 3.4 for service-search-nls:

- Changed reference to org.oskari maven dependencies for Oskari 2.0
- Upgraded GeoTools
- Fix for address search: MapfullHandler.PLUGIN_SEARCH was removed in 1.54.0. The dependency range allowed this to compile but it doesn't really work. 
