### PR TITLE
Version 3.5 for Oskari 2.0.1 with changed coordinate type

### DIFF
--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,15 +5,15 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>3.4</version>
+    <version>3.5</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
-        <!-- Any version after 1.52.0 -->
-        <oskari.version>[2.0.0,)</oskari.version>
+        <!-- Any version after 2.0.1 as it changed lon/lat on searches from string to double -->
+        <oskari.version>[2.0.1,)</oskari.version>
         <fi.mml.nameregister.version>1.0</fi.mml.nameregister.version>
         <geotools.version>23.2</geotools.version>
         <javax.xml.version>1.0</javax.xml.version>

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchServiceTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/channel/MetadataCatalogueChannelSearchServiceTest.java
@@ -97,10 +97,10 @@ public class MetadataCatalogueChannelSearchServiceTest {
             result = results.get(i);
             assertEquals("Title mismatch", "Title", result.getTitle());
             assertEquals("Description mismatch", "Abstract text.", result.getDescription());
-            assertEquals("Westbound longitude mismatch", "19.08317359", result.getWestBoundLongitude());
-            assertEquals("Southbound latitude mismatch", "59.45414258", result.getSouthBoundLatitude());
-            assertEquals("Eastbound longitude mismatch", "31.58672881", result.getEastBoundLongitude());
-            assertEquals("Northbound latitude mismatch", "70.09229553", result.getNorthBoundLatitude());
+            assertEquals("Westbound longitude mismatch", 19.08317359, result.getWestBoundLongitude(), 0.001);
+            assertEquals("Southbound latitude mismatch", 59.45414258, result.getSouthBoundLatitude(), 0.001);
+            assertEquals("Eastbound longitude mismatch", 31.58672881, result.getEastBoundLongitude(), 0.001);
+            assertEquals("Northbound latitude mismatch", 70.09229553, result.getNorthBoundLatitude(), 0.001);
             // FIXME: downloadable points to:
             // gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:protocol
             // which was previously parsed as boolean but in test XML it's "OGC:WMS-1.1.1-http-get-map" so ignoring for now...
@@ -155,10 +155,10 @@ public class MetadataCatalogueChannelSearchServiceTest {
             result = results.get(i);
             assertEquals("Title mismatch", "Title", result.getTitle());
             assertEquals("Description mismatch", "Abstract text.", result.getDescription());
-            assertEquals("Westbound longitude mismatch", "19.08317359", result.getWestBoundLongitude());
-            assertEquals("Southbound latitude mismatch", "59.45414258", result.getSouthBoundLatitude());
-            assertEquals("Eastbound longitude mismatch", "31.58672881", result.getEastBoundLongitude());
-            assertEquals("Northbound latitude mismatch", "70.09229553", result.getNorthBoundLatitude());
+            assertEquals("Westbound longitude mismatch", 19.08317359, result.getWestBoundLongitude(), 0.001);
+            assertEquals("Southbound latitude mismatch", 59.45414258, result.getSouthBoundLatitude(), 0.001);
+            assertEquals("Eastbound longitude mismatch", 31.58672881, result.getEastBoundLongitude(), 0.001);
+            assertEquals("Northbound latitude mismatch", 70.09229553, result.getNorthBoundLatitude(), 0.001);
             assertEquals("IsDownloadable mismatch", false, result.isDownloadable());
             assertEquals("GMD URL mismatch", "http://www.gee-em-dee.com", result.getGmdURL());
             assertEquals("Action URL mismatch", "fetchPageURL.fiUUIDUUID-UUID-UUID-UUID-UUIDUUIDUUID", result.getActionURL());

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/channel/TM35LehtijakoSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/channel/TM35LehtijakoSearchChannelTest.java
@@ -18,8 +18,8 @@ public class TM35LehtijakoSearchChannelTest {
         ChannelSearchResult result = instance.doSearch(searchCriteria);
         SearchResultItem item = result.getSearchResultItems().get(0);
 
-        assertEquals(548000.0d, Double.parseDouble(item.getLon()), 0.0d);
-        assertEquals(7506000.0d, Double.parseDouble(item.getLat()), 0.0d);
+        assertEquals(548000.0d, item.getLon(), 0.0d);
+        assertEquals(7506000.0d, item.getLat(), 0.0d);
     }
     @Test
     public void testDoSearchInvalidKeyword() {


### PR DESCRIPTION
The SearchResultItem was changed from 2.0.0 to 2.0.1 to have get/setLon() and get/setLat() as type double instead of String. This fixes an issue with reverse geocoding for the channels.