### PR TITLE
Add parametrization from client

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -128,11 +128,11 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
     }
 
     private Map<String, Object> getResult(SearchCriteria criteria) throws IOException {
-        String requestedEndpoint = (String) criteria.getParamAsString("endpoint");
+        String requestedEndpoint = criteria.getParamAsString(ID + "_endpoint");
         String url = getUrl(requestedEndpoint, getSearchParams(criteria.getSearchString(),
                 criteria.getLocale(),
                 criteria.getMaxResults(),
-                criteria.getParamAsString("sources")));
+                criteria.getParamAsString(ID + "_sources")));
 
         LOG.debug("Calling search with", url);
         HttpURLConnection conn = connectToService(url);

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
@@ -29,6 +29,7 @@ public class NLSFIGeocodingSearchChannelTest {
         }
         String user = "[this is an api key for testing]"; //apikey
         PropertyUtil.addProperty("search.channel." + NLSFIGeocodingSearchChannel.ID + ".APIkey", user);
+        PropertyUtil.addProperty("search.channel." + NLSFIGeocodingSearchChannel.ID + ".endpoint.test", "/xyz/testing");
         channel.init();
     }
 
@@ -45,7 +46,15 @@ public class NLSFIGeocodingSearchChannelTest {
                 "&sources=geographic-names%2Ccadastral-units%2Cinterpolated-road-addresses" +
                 "&crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3067" +
                 "&request-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3067";
-        assertEquals(expected, channel.getUrl(channel.getSearchParams("test", "fi", 5)));
+        assertEquals(expected, channel.getUrl(channel.getSearchParams("test", "fi", 5, null)));
+
+        String requestedSourcesExpected = "https://avoin-paikkatieto.maanmittauslaitos.fi/geocoding/xyz/testing?" +
+                "text=test" +
+                "&lang=fi&size=6" +
+                "&sources=testing%2Cmy%2Cdummy%2Csources" +
+                "&crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3067" +
+                "&request-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3067";
+        assertEquals(requestedSourcesExpected, channel.getUrl("test", channel.getSearchParams("test", "fi", 5, "testing,my,dummy,sources")));
     }
 
     @Test


### PR DESCRIPTION
Builds on:
https://github.com/oskariorg/oskari-frontend/pull/1688
https://github.com/oskariorg/oskari-server/pull/765

To allow sending parameters like:
```
Oskari.getSandbox().postRequestByName('SearchRequest', ['järvi', {
   'limit': 1000,
   'NLSFI_GEOCODING_endpoint': 'asiointi',
   'NLSFI_GEOCODING_sources': 'geographic-names,cadastral-units,interpolated-road-addresses',
}]);
```
To select a search end-point configured in oskari-ext.properties:
```
search.channel.NLSFI_GEOCODING.endpoint.asiointi=/v2/asiointi/search
# new option: hard limit for results regardless what client requests (defaults to 10x max results)
search.max.results.hardlimit=10000
```
