### PR TITLE
Make channels configurable for paramhandlers

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
@@ -38,7 +38,7 @@ public class AddressParamHandler extends ParamHandler {
         if(params.getParamValue() == null) {
             return false;
         }
-        final ArrayList<String[]> coordinates = getCoordinatesFromAddress(params.getParamValue(), params.getLocale());
+        final ArrayList<String[]> coordinates = getCoordinatesFromAddress(params.getParamValue(), params.getLocale(), params.getView().getSrsName());
         if (coordinates.isEmpty()) {
             return false;
         }
@@ -71,7 +71,7 @@ public class AddressParamHandler extends ParamHandler {
         return true;
     }
     protected ArrayList<String[]> getCoordinatesFromAddress(
-                              String searchString, Locale locale) {
+                              String searchString, Locale locale, String srs) {
 
         final ArrayList<String[]> lat_lon = new ArrayList<>();
 
@@ -79,6 +79,7 @@ public class AddressParamHandler extends ParamHandler {
         sc.addChannel(channelID);
         sc.setSearchString(searchString);
         sc.setLocale(locale.getLanguage());
+        sc.setSRS(srs);
 
         try {
             final Query query = searchService.doSearch(sc);

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralRefParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralRefParamHandler.java
@@ -48,7 +48,7 @@ public class NationalCadastralRefParamHandler extends ParamHandler {
         // we can use fi as language since we only get coordinates, could
         // get it from published map if needed
         final ArrayList<String[]> latlon_list = getCoordinatesFromNatCadRef(
-                params.getLocale(), cadastralRef, PropertyUtil.getDefaultLanguage());
+                params.getLocale(), cadastralRef, PropertyUtil.getDefaultLanguage(), params.getView().getSrsName());
         // TODO: KTJ search channel now returns "palstat" instead of
         // "kiinteistöt" -> one ref returns multiple results
         // we need to think this through
@@ -71,7 +71,7 @@ public class NationalCadastralRefParamHandler extends ParamHandler {
     }
 
     private ArrayList<String[]> getCoordinatesFromNatCadRef(Locale locale,
-            String searchString, String publishedMapLanguage) {
+            String searchString, String publishedMapLanguage, String srs) {
 
         ArrayList<String[]> lat_lon = new ArrayList<>();
 
@@ -90,6 +90,7 @@ public class NationalCadastralRefParamHandler extends ParamHandler {
                 //sc.addChannel(KTJkiiSearchChannel.ID);
                 sc.setSearchString(searchString);
                 sc.setLocale(locale.getLanguage());
+                sc.setSRS(srs);
 
                 Query query = searchService.doSearch(sc);
 

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralWFSHighlightParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralWFSHighlightParamHandler.java
@@ -6,6 +6,7 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.search.channel.KTJkiiSearchChannel;
 import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.view.modifier.ModifierException;
 import fi.nls.oskari.view.modifier.ModifierParams;
 import org.json.JSONArray;
@@ -13,11 +14,19 @@ import org.json.JSONObject;
 
 import java.util.List;
 
+/**
+ * @deprecated This is based on the old WFS-backend (transport) and would require changes for other parts of Oskari to make it work properly
+ */
 @OskariViewModifier("nationalCadastralReferenceHighlight")
 public class NationalCadastralWFSHighlightParamHandler extends WFSHighlightParamHandler {
 
     private static final Logger log = LogFactory.getLogger(NationalCadastralWFSHighlightParamHandler.class);
     private static SearchService searchService = new SearchServiceImpl();
+    private String channelID = KTJkiiSearchChannel.ID;
+
+    public void init() {
+        channelID = PropertyUtil.get("paramhandler.nationalCadastralReferenceHighlight.channel", channelID);
+    }
 
     @Override
     public boolean handleParam(ModifierParams params)
@@ -51,12 +60,12 @@ public class NationalCadastralWFSHighlightParamHandler extends WFSHighlightParam
     private List<SearchResultItem> getKTJfeature(final String param, final String language) {
 
         final SearchCriteria sc = new SearchCriteria();
-        sc.addChannel(KTJkiiSearchChannel.ID);
+        sc.addChannel(channelID);
         sc.setSearchString(param);
         sc.setLocale(language);
 
         final Query query = searchService.doSearch(sc);
-        return query.findResult(KTJkiiSearchChannel.ID).getSearchResultItems();
+        return query.findResult(channelID).getSearchResultItems();
     }
 
     private JSONArray calculateBbox(List<SearchResultItem> list) {

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralWFSHighlightParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/NationalCadastralWFSHighlightParamHandler.java
@@ -37,7 +37,7 @@ public class NationalCadastralWFSHighlightParamHandler extends WFSHighlightParam
         final JSONArray featureIdList = new JSONArray();
 
         List<SearchResultItem> list = getKTJfeature(params.getParamValue(),
-                params.getLocale().getLanguage());
+                params.getLocale().getLanguage(), params.getView().getSrsName());
         for (SearchResultItem item : list) {
             featureIdList.put(item.getResourceId());
         }
@@ -57,12 +57,13 @@ public class NationalCadastralWFSHighlightParamHandler extends WFSHighlightParam
         return featureIdList.length() > 0;
     }
 
-    private List<SearchResultItem> getKTJfeature(final String param, final String language) {
+    private List<SearchResultItem> getKTJfeature(final String param, final String language, String srs) {
 
         final SearchCriteria sc = new SearchCriteria();
         sc.addChannel(channelID);
         sc.setSearchString(param);
         sc.setLocale(language);
+        sc.setSRS(srs);
 
         final Query query = searchService.doSearch(sc);
         return query.findResult(channelID).getSearchResultItems();

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -208,7 +208,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
     }
 
     private boolean requiresReprojection(String srs) {
-        return !("EPSG:" + SERVICE_SRS_CODE).equals(srs);
+        return srs != null && !("EPSG:" + SERVICE_SRS_CODE).equals(srs);
     }
 
     protected String getEndpoint() {

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -161,6 +161,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         SearchResultItem item = new SearchResultItem();
         item.setLat(feat.y);
         item.setLon(feat.x);
+        item.setContentURL(feat.x + "_" + feat.y);
 
         // all features seems to have label, geonames have "name" that is an object
         //item.setLocationName((String) feat.properties.get("label"));


### PR DESCRIPTION
Defaults to existing values but to use NLS FI geocoding it's now possible to configure the search channel:
```
paramhandler.address.channel=NLSFI_GEOCODING
paramhandler.nationalCadastralReference.channels=NLSFI_GEOCODING
paramhandler.nationalCadastralReferenceHighlight.channel=NLSFI_GEOCODING
```
Note! Also changes address search for geoportal: if there's more than one result -> use the first one. Also don't try getting coordinates if the result is empty.