### PR TITLE
Ogc api search

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/search/channel/OgcApiSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/channel/OgcApiSearchChannel.java
@@ -29,11 +29,20 @@ public class OgcApiSearchChannel extends SearchChannel {
     public static final String ID = "OGC_API_SEARCH_CHANNEL";
 
     //Local configs
+    /**
+     * One can use property search.channel.OGC_API_SEARCH_CHANNEL.apikey but if really needed apikey can go here.
+     */
     private static String apiKey = null;
     private static String searchAddress = "https://avoin-paikkatieto.maanmittauslaitos.fi/geographic-names/features/v1/collections/placenames/items?spelling_case_insensitive=";
     private static String additionalPlaceTypeInfoBaseUrl = "https://beta-paikkatieto.maanmittauslaitos.fi/catalogue/v1/codelistgroups/geographic-names/codelists/";
     private static String[] localAdditionalInfoNames = {"placeType", "municipality"};
+    /**
+     * Set true if one wants to use local jsons instead of url based one
+     */
     private static final boolean USE_LOCAL_ADDITIONAL_INFO = true;
+    /**
+     * Add languages you have translaited here as language code
+     */
     private static String[] languageArray = {"fin", "eng", "swe"};
 
     private static HashMap<Integer, HashMap<String, String>> placetypeCodes;

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/channel/OgcApiSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/channel/OgcApiSearchChannel.java
@@ -1,0 +1,193 @@
+package fi.nls.oskari.search.channel;
+
+import fi.mml.portti.service.search.ChannelSearchResult;
+import fi.mml.portti.service.search.SearchCriteria;
+import fi.mml.portti.service.search.SearchResultItem;
+import fi.nls.oskari.annotation.Oskari;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.search.channel.SearchChannel;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+
+@Oskari(OgcApiSearchChannel.ID)
+public class OgcApiSearchChannel extends SearchChannel {
+
+
+    public static final String ID = "OGC_API_SEARCH_CHANNEL";
+
+    //Local configs
+    private static String apiKey = null;
+    private static String searchAddress = "https://avoin-paikkatieto.maanmittauslaitos.fi/geographic-names/features/v1/collections/placenames/items?spelling_case_insensitive=";
+    private static String additionalPlaceTypeInfoBaseUrl = "https://beta-paikkatieto.maanmittauslaitos.fi/catalogue/v1/codelistgroups/geographic-names/codelists/";
+    private static String[] localAdditionalInfoNames = {"placeType", "municipality"};
+    private static final boolean USE_LOCAL_ADDITIONAL_INFO = true;
+    private static String[] languageArray = {"fin", "eng", "swe"};
+
+    private static HashMap<Integer, HashMap<String, String>> placetypeCodes;
+    private static HashMap<Integer, HashMap<String, String>> municipalityCodes;
+
+    private Logger log = LogFactory.getLogger(this.getClass());
+
+    private static String CRS = null;
+    private static final String defaultCRS = "http://www.opengis.net/def/crs/EPSG/0/3067";
+
+
+    public ChannelSearchResult doSearch(SearchCriteria criteria) {
+        ChannelSearchResult result = new ChannelSearchResult();
+
+        if (placetypeCodes == null) {
+            placetypeCodes = buildAdditionalInfo(localAdditionalInfoNames[0]);
+        }
+        if (municipalityCodes == null) {
+            municipalityCodes = buildAdditionalInfo(localAdditionalInfoNames[1]);
+        }
+
+        //ApiKey Things
+        String propertyKey = PropertyUtil.get("search.channel." + ID + ".apikey");
+        if (propertyKey != null) {
+            String encodedApiKey = IOHelper.encode64(propertyKey + ":");
+            apiKey = "Basic " + encodedApiKey;
+
+        }
+        if (apiKey == null) {
+            log.error("OGC Api key was not found. OGC api will not return results.");
+        }
+        Map<String, String> headers = new HashMap<>(5);
+        headers.put("Authorization", apiKey);
+
+        String encodedSearchTerm = "";
+        try {
+            encodedSearchTerm = URLEncoder.encode(criteria.getSearchString(), StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        String searchQuerry = searchAddress + encodedSearchTerm + "&limit=" + criteria.getMaxResults();
+
+        CRS = PropertyUtil.get("OgcApiCrs", defaultCRS);
+        if (CRS != null) {
+            searchQuerry += "&crs=" + CRS;
+        }
+
+        try {
+            final String responseData = IOHelper.getURL(searchQuerry, headers);
+
+            JSONObject responseDataObject = new JSONObject(responseData);
+            JSONArray features = responseDataObject.getJSONArray("features");
+            for (int i = 0; i < features.length(); i++) {
+                JSONObject feature = features.getJSONObject(i);
+                JSONObject properties = feature.getJSONObject("properties");
+                JSONArray coordinates = feature.getJSONObject("geometry").getJSONArray("coordinates");
+
+
+                //Make SearchItem
+                SearchResultItem item = new SearchResultItem();
+                item.setTitle(properties.getString("spelling"));
+                item.setType(placetypeCodes.get(properties.getInt(localAdditionalInfoNames[0])).get(properties.getString("language")));
+                item.setLon(Double.parseDouble(coordinates.get(0).toString()));
+                item.setLat(Double.parseDouble(coordinates.get(1).toString()));
+                item.setZoomScale(properties.getDouble("scaleRelevance"));
+                item.setRegion(municipalityCodes.get(properties.getInt(localAdditionalInfoNames[1])).get(properties.getString("language")));
+                result.addItem(item);
+
+            }
+
+        } catch (IOException ex) {
+            throw new RuntimeException("Error searching", ex);
+        } catch (JSONException e) {
+            log.warn("Json error during building and/or making of Search results", e);
+        }
+        return result;
+    }
+
+    /**
+     * Chooses when ever to use local or url based resource to make code hashmaps.
+     *
+     * @param thing
+     * @return
+     */
+    private HashMap<Integer, HashMap<String, String>> buildAdditionalInfo(String thing) {
+        HashMap<Integer, HashMap<String, String>> results;
+        if (USE_LOCAL_ADDITIONAL_INFO) {
+            results = buildAdditionalInfoFromLocals(thing);
+        } else {
+            results = buildAdditionalInfoFromURL(additionalPlaceTypeInfoBaseUrl + thing + "/items");
+        }
+        return results;
+    }
+
+    /**
+     * Takes url suffix in and constructs string represantation of that file.
+     *
+     * @param infoURL
+     * @return HashMap that holds id to hashmap of languages.
+     */
+    private HashMap<Integer, HashMap<String, String>> buildAdditionalInfoFromURL(String infoURL) {
+        HashMap<Integer, HashMap<String, String>> results = new HashMap<>();
+        for (int i = 0; i < languageArray.length; i++) {
+            try {
+                final String responseData = IOHelper.getURL(infoURL + "?lang=" + languageArray[i]);
+                buildLanguageInfoMap(results, responseData);
+
+            } catch (IOException ex) {
+                throw new RuntimeException("Error getting additional information", ex);
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Takes file suffix in and constructs string represantation of that file.
+     *
+     * @param fileSuffix
+     * @return HashMap that holds id to hashmap of languages.
+     */
+    private HashMap<Integer, HashMap<String, String>> buildAdditionalInfoFromLocals(String fileSuffix) {
+        HashMap<Integer, HashMap<String, String>> results = new HashMap<>();
+        for (int i = 0; i < languageArray.length; i++) {
+            InputStream inputStreamFromFile = OgcApiSearchChannel.class.getResourceAsStream(ID + "_" + fileSuffix.toLowerCase() + "_" + languageArray[i] + ".json");
+            Scanner s = new Scanner(inputStreamFromFile, "UTF-8").useDelimiter("\\A");
+            String fileAsString = s.hasNext() ? s.next() : "";
+            buildLanguageInfoMap(results, fileAsString);
+
+        }
+        return results;
+    }
+
+    /**
+     * Goes through Json and adds all the label data to Hashmap that holds language id pairs.
+     *
+     * @param results: HashMap to fill with results.
+     * @param responseData: The full json where to parse everything.
+     */
+    private void buildLanguageInfoMap(HashMap<Integer, HashMap<String, String>> results, String responseData) {
+        try {
+            JSONObject values = (new JSONObject(responseData)).getJSONObject("values");
+            for (int j = 0; j < values.names().length(); j++) {
+
+                JSONObject singularValue = values.getJSONObject(values.names().get(j).toString());
+                int value = Integer.parseInt(singularValue.getString("value"));
+                HashMap<String, String> languageMap = results.getOrDefault(value, new HashMap<>(3));
+                languageMap.put(singularValue.getString("lang"), singularValue.getString("label"));
+                results.remove(value);
+                results.put(value, languageMap);
+
+            }
+        } catch (JSONException ex) {
+            throw new RuntimeException("Error constructing additional info json object", ex);
+        }
+    }
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_eng.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_eng.json
@@ -1,0 +1,2478 @@
+{
+  "name" : "municipality",
+  "values" : {
+    "005" : {
+      "value" : "005",
+      "label" : "Alajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "009" : {
+      "value" : "009",
+      "label" : "Alavieska",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "010" : {
+      "value" : "010",
+      "label" : "Alavus",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "016" : {
+      "value" : "016",
+      "label" : "Asikkala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "018" : {
+      "value" : "018",
+      "label" : "Askola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "019" : {
+      "value" : "019",
+      "label" : "Aura",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "020" : {
+      "value" : "020",
+      "label" : "Akaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "035" : {
+      "value" : "035",
+      "label" : "Brändö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "043" : {
+      "value" : "043",
+      "label" : "Eckerö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "046" : {
+      "value" : "046",
+      "label" : "Enonkoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "047" : {
+      "value" : "047",
+      "label" : "Enontekiö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "049" : {
+      "value" : "049",
+      "label" : "Espoo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "050" : {
+      "value" : "050",
+      "label" : "Eura",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "051" : {
+      "value" : "051",
+      "label" : "Eurajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "052" : {
+      "value" : "052",
+      "label" : "Evijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "060" : {
+      "value" : "060",
+      "label" : "Finström",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "061" : {
+      "value" : "061",
+      "label" : "Forssa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "062" : {
+      "value" : "062",
+      "label" : "Föglö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "065" : {
+      "value" : "065",
+      "label" : "Geta",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "069" : {
+      "value" : "069",
+      "label" : "Haapajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "071" : {
+      "value" : "071",
+      "label" : "Haapavesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "072" : {
+      "value" : "072",
+      "label" : "Hailuoto",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "074" : {
+      "value" : "074",
+      "label" : "Halsua",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "075" : {
+      "value" : "075",
+      "label" : "Hamina",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "076" : {
+      "value" : "076",
+      "label" : "Hammarland",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "077" : {
+      "value" : "077",
+      "label" : "Hankasalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "078" : {
+      "value" : "078",
+      "label" : "Hanko",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "079" : {
+      "value" : "079",
+      "label" : "Harjavalta",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "081" : {
+      "value" : "081",
+      "label" : "Hartola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "082" : {
+      "value" : "082",
+      "label" : "Hattula",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "086" : {
+      "value" : "086",
+      "label" : "Hausjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "090" : {
+      "value" : "090",
+      "label" : "Heinävesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "091" : {
+      "value" : "091",
+      "label" : "Helsinki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "092" : {
+      "value" : "092",
+      "label" : "Vantaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "097" : {
+      "value" : "097",
+      "label" : "Hirvensalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "098" : {
+      "value" : "098",
+      "label" : "Hollola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "102" : {
+      "value" : "102",
+      "label" : "Huittinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "103" : {
+      "value" : "103",
+      "label" : "Humppila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "105" : {
+      "value" : "105",
+      "label" : "Hyrynsalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "106" : {
+      "value" : "106",
+      "label" : "Hyvinkää",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "108" : {
+      "value" : "108",
+      "label" : "Hämeenkyrö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "109" : {
+      "value" : "109",
+      "label" : "Hämeenlinna",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "111" : {
+      "value" : "111",
+      "label" : "Heinola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "139" : {
+      "value" : "139",
+      "label" : "Ii",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "140" : {
+      "value" : "140",
+      "label" : "Iisalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "142" : {
+      "value" : "142",
+      "label" : "Iitti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "143" : {
+      "value" : "143",
+      "label" : "Ikaalinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "145" : {
+      "value" : "145",
+      "label" : "Ilmajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "146" : {
+      "value" : "146",
+      "label" : "Ilomantsi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "148" : {
+      "value" : "148",
+      "label" : "Inari",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "149" : {
+      "value" : "149",
+      "label" : "Ingå",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "151" : {
+      "value" : "151",
+      "label" : "Isojoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "152" : {
+      "value" : "152",
+      "label" : "Isokyrö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "153" : {
+      "value" : "153",
+      "label" : "Imatra",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "165" : {
+      "value" : "165",
+      "label" : "Janakkala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "167" : {
+      "value" : "167",
+      "label" : "Joensuu",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "169" : {
+      "value" : "169",
+      "label" : "Jokioinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "170" : {
+      "value" : "170",
+      "label" : "Jomala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "171" : {
+      "value" : "171",
+      "label" : "Joroinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "172" : {
+      "value" : "172",
+      "label" : "Joutsa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "176" : {
+      "value" : "176",
+      "label" : "Juuka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "177" : {
+      "value" : "177",
+      "label" : "Juupajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "178" : {
+      "value" : "178",
+      "label" : "Juva",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "179" : {
+      "value" : "179",
+      "label" : "Jyväskylä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "181" : {
+      "value" : "181",
+      "label" : "Jämijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "182" : {
+      "value" : "182",
+      "label" : "Jämsä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "186" : {
+      "value" : "186",
+      "label" : "Järvenpää",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "202" : {
+      "value" : "202",
+      "label" : "Kaarina",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "204" : {
+      "value" : "204",
+      "label" : "Kaavi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "205" : {
+      "value" : "205",
+      "label" : "Kajaani",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "208" : {
+      "value" : "208",
+      "label" : "Kalajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "211" : {
+      "value" : "211",
+      "label" : "Kangasala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "213" : {
+      "value" : "213",
+      "label" : "Kangasniemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "214" : {
+      "value" : "214",
+      "label" : "Kankaanpää",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "216" : {
+      "value" : "216",
+      "label" : "Kannonkoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "217" : {
+      "value" : "217",
+      "label" : "Kannus",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "218" : {
+      "value" : "218",
+      "label" : "Karijoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "224" : {
+      "value" : "224",
+      "label" : "Karkkila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "226" : {
+      "value" : "226",
+      "label" : "Karstula",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "230" : {
+      "value" : "230",
+      "label" : "Karvia",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "231" : {
+      "value" : "231",
+      "label" : "Kaskinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "232" : {
+      "value" : "232",
+      "label" : "Kauhajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "233" : {
+      "value" : "233",
+      "label" : "Kauhava",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "235" : {
+      "value" : "235",
+      "label" : "Kauniainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "236" : {
+      "value" : "236",
+      "label" : "Kaustinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "239" : {
+      "value" : "239",
+      "label" : "Keitele",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "240" : {
+      "value" : "240",
+      "label" : "Kemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "241" : {
+      "value" : "241",
+      "label" : "Keminmaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "244" : {
+      "value" : "244",
+      "label" : "Kempele",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "245" : {
+      "value" : "245",
+      "label" : "Kerava",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "249" : {
+      "value" : "249",
+      "label" : "Keuruu",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "250" : {
+      "value" : "250",
+      "label" : "Kihniö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "256" : {
+      "value" : "256",
+      "label" : "Kinnula",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "257" : {
+      "value" : "257",
+      "label" : "Kirkkonummi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "260" : {
+      "value" : "260",
+      "label" : "Kitee",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "261" : {
+      "value" : "261",
+      "label" : "Kittilä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "263" : {
+      "value" : "263",
+      "label" : "Kiuruvesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "265" : {
+      "value" : "265",
+      "label" : "Kivijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "271" : {
+      "value" : "271",
+      "label" : "Kokemäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "272" : {
+      "value" : "272",
+      "label" : "Kokkola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "273" : {
+      "value" : "273",
+      "label" : "Kolari",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "275" : {
+      "value" : "275",
+      "label" : "Konnevesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "276" : {
+      "value" : "276",
+      "label" : "Kontiolahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "280" : {
+      "value" : "280",
+      "label" : "Korsnäs",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "284" : {
+      "value" : "284",
+      "label" : "Koski Tl",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "285" : {
+      "value" : "285",
+      "label" : "Kotka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "286" : {
+      "value" : "286",
+      "label" : "Kouvola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "287" : {
+      "value" : "287",
+      "label" : "Kristinestad",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "288" : {
+      "value" : "288",
+      "label" : "Kronoby",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "290" : {
+      "value" : "290",
+      "label" : "Kuhmo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "291" : {
+      "value" : "291",
+      "label" : "Kuhmoinen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "295" : {
+      "value" : "295",
+      "label" : "Kumlinge",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "297" : {
+      "value" : "297",
+      "label" : "Kuopio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "300" : {
+      "value" : "300",
+      "label" : "Kuortane",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "301" : {
+      "value" : "301",
+      "label" : "Kurikka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "304" : {
+      "value" : "304",
+      "label" : "Kustavi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "305" : {
+      "value" : "305",
+      "label" : "Kuusamo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "309" : {
+      "value" : "309",
+      "label" : "Outokumpu",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "312" : {
+      "value" : "312",
+      "label" : "Kyyjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "316" : {
+      "value" : "316",
+      "label" : "Kärkölä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "317" : {
+      "value" : "317",
+      "label" : "Kärsämäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "318" : {
+      "value" : "318",
+      "label" : "Kökar",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "320" : {
+      "value" : "320",
+      "label" : "Kemijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "322" : {
+      "value" : "322",
+      "label" : "Kimitoön",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "398" : {
+      "value" : "398",
+      "label" : "Lahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "399" : {
+      "value" : "399",
+      "label" : "Laihia",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "400" : {
+      "value" : "400",
+      "label" : "Laitila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "402" : {
+      "value" : "402",
+      "label" : "Lapinlahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "403" : {
+      "value" : "403",
+      "label" : "Lappajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "405" : {
+      "value" : "405",
+      "label" : "Lappeenranta",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "407" : {
+      "value" : "407",
+      "label" : "Lapinjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "408" : {
+      "value" : "408",
+      "label" : "Lapua",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "410" : {
+      "value" : "410",
+      "label" : "Laukaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "416" : {
+      "value" : "416",
+      "label" : "Lemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "417" : {
+      "value" : "417",
+      "label" : "Lemland",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "418" : {
+      "value" : "418",
+      "label" : "Lempäälä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "420" : {
+      "value" : "420",
+      "label" : "Leppävirta",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "421" : {
+      "value" : "421",
+      "label" : "Lestijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "422" : {
+      "value" : "422",
+      "label" : "Lieksa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "423" : {
+      "value" : "423",
+      "label" : "Lieto",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "425" : {
+      "value" : "425",
+      "label" : "Liminka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "426" : {
+      "value" : "426",
+      "label" : "Liperi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "430" : {
+      "value" : "430",
+      "label" : "Loimaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "433" : {
+      "value" : "433",
+      "label" : "Loppi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "434" : {
+      "value" : "434",
+      "label" : "Loviisa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "435" : {
+      "value" : "435",
+      "label" : "Luhanka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "436" : {
+      "value" : "436",
+      "label" : "Lumijoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "438" : {
+      "value" : "438",
+      "label" : "Lumparland",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "440" : {
+      "value" : "440",
+      "label" : "Larsmo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "441" : {
+      "value" : "441",
+      "label" : "Luumäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "444" : {
+      "value" : "444",
+      "label" : "Lohja",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "445" : {
+      "value" : "445",
+      "label" : "Pargas",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "475" : {
+      "value" : "475",
+      "label" : "Malax",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "478" : {
+      "value" : "478",
+      "label" : "Mariehamn",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "480" : {
+      "value" : "480",
+      "label" : "Marttila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "481" : {
+      "value" : "481",
+      "label" : "Masku",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "483" : {
+      "value" : "483",
+      "label" : "Merijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "484" : {
+      "value" : "484",
+      "label" : "Merikarvia",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "489" : {
+      "value" : "489",
+      "label" : "Miehikkälä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "491" : {
+      "value" : "491",
+      "label" : "Mikkeli",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "494" : {
+      "value" : "494",
+      "label" : "Muhos",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "495" : {
+      "value" : "495",
+      "label" : "Multia",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "498" : {
+      "value" : "498",
+      "label" : "Muonio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "499" : {
+      "value" : "499",
+      "label" : "Korsholm",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "500" : {
+      "value" : "500",
+      "label" : "Muurame",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "503" : {
+      "value" : "503",
+      "label" : "Mynämäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "504" : {
+      "value" : "504",
+      "label" : "Myrskylä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "505" : {
+      "value" : "505",
+      "label" : "Mäntsälä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "507" : {
+      "value" : "507",
+      "label" : "Mäntyharju",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "508" : {
+      "value" : "508",
+      "label" : "Mänttä-Vilppula",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "529" : {
+      "value" : "529",
+      "label" : "Naantali",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "531" : {
+      "value" : "531",
+      "label" : "Nakkila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "535" : {
+      "value" : "535",
+      "label" : "Nivala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "536" : {
+      "value" : "536",
+      "label" : "Nokia",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "538" : {
+      "value" : "538",
+      "label" : "Nousiainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "541" : {
+      "value" : "541",
+      "label" : "Nurmes",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "543" : {
+      "value" : "543",
+      "label" : "Nurmijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "545" : {
+      "value" : "545",
+      "label" : "Närpes",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "560" : {
+      "value" : "560",
+      "label" : "Orimattila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "561" : {
+      "value" : "561",
+      "label" : "Oripää",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "562" : {
+      "value" : "562",
+      "label" : "Orivesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "563" : {
+      "value" : "563",
+      "label" : "Oulainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "564" : {
+      "value" : "564",
+      "label" : "Oulu",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "576" : {
+      "value" : "576",
+      "label" : "Padasjoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "577" : {
+      "value" : "577",
+      "label" : "Paimio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "578" : {
+      "value" : "578",
+      "label" : "Paltamo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "580" : {
+      "value" : "580",
+      "label" : "Parikkala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "581" : {
+      "value" : "581",
+      "label" : "Parkano",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "583" : {
+      "value" : "583",
+      "label" : "Pelkosenniemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "584" : {
+      "value" : "584",
+      "label" : "Perho",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "588" : {
+      "value" : "588",
+      "label" : "Pertunmaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "592" : {
+      "value" : "592",
+      "label" : "Petäjävesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "593" : {
+      "value" : "593",
+      "label" : "Pieksämäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "595" : {
+      "value" : "595",
+      "label" : "Pielavesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "598" : {
+      "value" : "598",
+      "label" : "Jakobstad",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "599" : {
+      "value" : "599",
+      "label" : "Pedersöre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "601" : {
+      "value" : "601",
+      "label" : "Pihtipudas",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "604" : {
+      "value" : "604",
+      "label" : "Pirkkala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "607" : {
+      "value" : "607",
+      "label" : "Polvijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "608" : {
+      "value" : "608",
+      "label" : "Pomarkku",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "609" : {
+      "value" : "609",
+      "label" : "Pori",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "611" : {
+      "value" : "611",
+      "label" : "Pornainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "614" : {
+      "value" : "614",
+      "label" : "Posio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "615" : {
+      "value" : "615",
+      "label" : "Pudasjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "616" : {
+      "value" : "616",
+      "label" : "Pukkila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "619" : {
+      "value" : "619",
+      "label" : "Punkalaidun",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "620" : {
+      "value" : "620",
+      "label" : "Puolanka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "623" : {
+      "value" : "623",
+      "label" : "Puumala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "624" : {
+      "value" : "624",
+      "label" : "Pyhtää",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "625" : {
+      "value" : "625",
+      "label" : "Pyhäjoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "626" : {
+      "value" : "626",
+      "label" : "Pyhäjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "630" : {
+      "value" : "630",
+      "label" : "Pyhäntä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "631" : {
+      "value" : "631",
+      "label" : "Pyhäranta",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "635" : {
+      "value" : "635",
+      "label" : "Pälkäne",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "636" : {
+      "value" : "636",
+      "label" : "Pöytyä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "638" : {
+      "value" : "638",
+      "label" : "Porvoo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "678" : {
+      "value" : "678",
+      "label" : "Raahe",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "680" : {
+      "value" : "680",
+      "label" : "Raisio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "681" : {
+      "value" : "681",
+      "label" : "Rantasalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "683" : {
+      "value" : "683",
+      "label" : "Ranua",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "684" : {
+      "value" : "684",
+      "label" : "Rauma",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "686" : {
+      "value" : "686",
+      "label" : "Rautalampi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "687" : {
+      "value" : "687",
+      "label" : "Rautavaara",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "689" : {
+      "value" : "689",
+      "label" : "Rautjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "691" : {
+      "value" : "691",
+      "label" : "Reisjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "694" : {
+      "value" : "694",
+      "label" : "Riihimäki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "697" : {
+      "value" : "697",
+      "label" : "Ristijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "698" : {
+      "value" : "698",
+      "label" : "Rovaniemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "700" : {
+      "value" : "700",
+      "label" : "Ruokolahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "702" : {
+      "value" : "702",
+      "label" : "Ruovesi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "704" : {
+      "value" : "704",
+      "label" : "Rusko",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "707" : {
+      "value" : "707",
+      "label" : "Rääkkylä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "710" : {
+      "value" : "710",
+      "label" : "Raseborg",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "729" : {
+      "value" : "729",
+      "label" : "Saarijärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "732" : {
+      "value" : "732",
+      "label" : "Salla",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "734" : {
+      "value" : "734",
+      "label" : "Salo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "736" : {
+      "value" : "736",
+      "label" : "Saltvik",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "738" : {
+      "value" : "738",
+      "label" : "Sauvo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "739" : {
+      "value" : "739",
+      "label" : "Savitaipale",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "740" : {
+      "value" : "740",
+      "label" : "Savonlinna",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "742" : {
+      "value" : "742",
+      "label" : "Savukoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "743" : {
+      "value" : "743",
+      "label" : "Seinäjoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "746" : {
+      "value" : "746",
+      "label" : "Sievi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "747" : {
+      "value" : "747",
+      "label" : "Siikainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "748" : {
+      "value" : "748",
+      "label" : "Siikajoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "749" : {
+      "value" : "749",
+      "label" : "Siilinjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "751" : {
+      "value" : "751",
+      "label" : "Simo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "753" : {
+      "value" : "753",
+      "label" : "Sipoo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "755" : {
+      "value" : "755",
+      "label" : "Siuntio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "758" : {
+      "value" : "758",
+      "label" : "Sodankylä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "759" : {
+      "value" : "759",
+      "label" : "Soini",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "761" : {
+      "value" : "761",
+      "label" : "Somero",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "762" : {
+      "value" : "762",
+      "label" : "Sonkajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "765" : {
+      "value" : "765",
+      "label" : "Sotkamo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "766" : {
+      "value" : "766",
+      "label" : "Sottunga",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "768" : {
+      "value" : "768",
+      "label" : "Sulkava",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "771" : {
+      "value" : "771",
+      "label" : "Sund",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "777" : {
+      "value" : "777",
+      "label" : "Suomussalmi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "778" : {
+      "value" : "778",
+      "label" : "Suonenjoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "781" : {
+      "value" : "781",
+      "label" : "Sysmä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "783" : {
+      "value" : "783",
+      "label" : "Säkylä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "785" : {
+      "value" : "785",
+      "label" : "Vaala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "790" : {
+      "value" : "790",
+      "label" : "Sastamala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "791" : {
+      "value" : "791",
+      "label" : "Siikalatva",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "831" : {
+      "value" : "831",
+      "label" : "Taipalsaari",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "832" : {
+      "value" : "832",
+      "label" : "Taivalkoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "833" : {
+      "value" : "833",
+      "label" : "Taivassalo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "834" : {
+      "value" : "834",
+      "label" : "Tammela",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "837" : {
+      "value" : "837",
+      "label" : "Tampere",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "844" : {
+      "value" : "844",
+      "label" : "Tervo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "845" : {
+      "value" : "845",
+      "label" : "Tervola",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "846" : {
+      "value" : "846",
+      "label" : "Teuva",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "848" : {
+      "value" : "848",
+      "label" : "Tohmajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "849" : {
+      "value" : "849",
+      "label" : "Toholampi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "850" : {
+      "value" : "850",
+      "label" : "Toivakka",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "851" : {
+      "value" : "851",
+      "label" : "Tornio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "853" : {
+      "value" : "853",
+      "label" : "Turku",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "854" : {
+      "value" : "854",
+      "label" : "Pello",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "857" : {
+      "value" : "857",
+      "label" : "Tuusniemi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "858" : {
+      "value" : "858",
+      "label" : "Tuusula",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "859" : {
+      "value" : "859",
+      "label" : "Tyrnävä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "886" : {
+      "value" : "886",
+      "label" : "Ulvila",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "887" : {
+      "value" : "887",
+      "label" : "Urjala",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "889" : {
+      "value" : "889",
+      "label" : "Utajärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "890" : {
+      "value" : "890",
+      "label" : "Utsjoki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "892" : {
+      "value" : "892",
+      "label" : "Uurainen",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "893" : {
+      "value" : "893",
+      "label" : "Nykarleby",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "895" : {
+      "value" : "895",
+      "label" : "Uusikaupunki",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "905" : {
+      "value" : "905",
+      "label" : "Vaasa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "908" : {
+      "value" : "908",
+      "label" : "Valkeakoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "915" : {
+      "value" : "915",
+      "label" : "Varkaus",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "918" : {
+      "value" : "918",
+      "label" : "Vehmaa",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "921" : {
+      "value" : "921",
+      "label" : "Vesanto",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "922" : {
+      "value" : "922",
+      "label" : "Vesilahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "924" : {
+      "value" : "924",
+      "label" : "Veteli",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "925" : {
+      "value" : "925",
+      "label" : "Vieremä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "927" : {
+      "value" : "927",
+      "label" : "Vihti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "931" : {
+      "value" : "931",
+      "label" : "Viitasaari",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "934" : {
+      "value" : "934",
+      "label" : "Vimpeli",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "935" : {
+      "value" : "935",
+      "label" : "Virolahti",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "936" : {
+      "value" : "936",
+      "label" : "Virrat",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "941" : {
+      "value" : "941",
+      "label" : "Vårdö",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "946" : {
+      "value" : "946",
+      "label" : "Vörå",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "976" : {
+      "value" : "976",
+      "label" : "Ylitornio",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "977" : {
+      "value" : "977",
+      "label" : "Ylivieska",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "980" : {
+      "value" : "980",
+      "label" : "Ylöjärvi",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "981" : {
+      "value" : "981",
+      "label" : "Ypäjä",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "989" : {
+      "value" : "989",
+      "label" : "Ähtäri",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "992" : {
+      "value" : "992",
+      "label" : "Äänekoski",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_fin.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_fin.json
@@ -1,0 +1,2478 @@
+{
+  "name" : "municipality",
+  "values" : {
+    "005" : {
+      "value" : "005",
+      "label" : "Alajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "009" : {
+      "value" : "009",
+      "label" : "Alavieska",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "010" : {
+      "value" : "010",
+      "label" : "Alavus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "016" : {
+      "value" : "016",
+      "label" : "Asikkala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "018" : {
+      "value" : "018",
+      "label" : "Askola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "019" : {
+      "value" : "019",
+      "label" : "Aura",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "020" : {
+      "value" : "020",
+      "label" : "Akaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "035" : {
+      "value" : "035",
+      "label" : "Brändö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "043" : {
+      "value" : "043",
+      "label" : "Eckerö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "046" : {
+      "value" : "046",
+      "label" : "Enonkoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "047" : {
+      "value" : "047",
+      "label" : "Enontekiö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "049" : {
+      "value" : "049",
+      "label" : "Espoo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "050" : {
+      "value" : "050",
+      "label" : "Eura",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "051" : {
+      "value" : "051",
+      "label" : "Eurajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "052" : {
+      "value" : "052",
+      "label" : "Evijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "060" : {
+      "value" : "060",
+      "label" : "Finström",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "061" : {
+      "value" : "061",
+      "label" : "Forssa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "062" : {
+      "value" : "062",
+      "label" : "Föglö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "065" : {
+      "value" : "065",
+      "label" : "Geta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "069" : {
+      "value" : "069",
+      "label" : "Haapajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "071" : {
+      "value" : "071",
+      "label" : "Haapavesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "072" : {
+      "value" : "072",
+      "label" : "Hailuoto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "074" : {
+      "value" : "074",
+      "label" : "Halsua",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "075" : {
+      "value" : "075",
+      "label" : "Hamina",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "076" : {
+      "value" : "076",
+      "label" : "Hammarland",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "077" : {
+      "value" : "077",
+      "label" : "Hankasalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "078" : {
+      "value" : "078",
+      "label" : "Hanko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "079" : {
+      "value" : "079",
+      "label" : "Harjavalta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "081" : {
+      "value" : "081",
+      "label" : "Hartola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "082" : {
+      "value" : "082",
+      "label" : "Hattula",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "086" : {
+      "value" : "086",
+      "label" : "Hausjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "090" : {
+      "value" : "090",
+      "label" : "Heinävesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "091" : {
+      "value" : "091",
+      "label" : "Helsinki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "092" : {
+      "value" : "092",
+      "label" : "Vantaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "097" : {
+      "value" : "097",
+      "label" : "Hirvensalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "098" : {
+      "value" : "098",
+      "label" : "Hollola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "102" : {
+      "value" : "102",
+      "label" : "Huittinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "103" : {
+      "value" : "103",
+      "label" : "Humppila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "105" : {
+      "value" : "105",
+      "label" : "Hyrynsalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "106" : {
+      "value" : "106",
+      "label" : "Hyvinkää",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "108" : {
+      "value" : "108",
+      "label" : "Hämeenkyrö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "109" : {
+      "value" : "109",
+      "label" : "Hämeenlinna",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "111" : {
+      "value" : "111",
+      "label" : "Heinola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "139" : {
+      "value" : "139",
+      "label" : "Ii",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "140" : {
+      "value" : "140",
+      "label" : "Iisalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "142" : {
+      "value" : "142",
+      "label" : "Iitti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "143" : {
+      "value" : "143",
+      "label" : "Ikaalinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "145" : {
+      "value" : "145",
+      "label" : "Ilmajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "146" : {
+      "value" : "146",
+      "label" : "Ilomantsi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "148" : {
+      "value" : "148",
+      "label" : "Inari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "149" : {
+      "value" : "149",
+      "label" : "Inkoo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "151" : {
+      "value" : "151",
+      "label" : "Isojoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "152" : {
+      "value" : "152",
+      "label" : "Isokyrö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "153" : {
+      "value" : "153",
+      "label" : "Imatra",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "165" : {
+      "value" : "165",
+      "label" : "Janakkala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "167" : {
+      "value" : "167",
+      "label" : "Joensuu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "169" : {
+      "value" : "169",
+      "label" : "Jokioinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "170" : {
+      "value" : "170",
+      "label" : "Jomala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "171" : {
+      "value" : "171",
+      "label" : "Joroinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "172" : {
+      "value" : "172",
+      "label" : "Joutsa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "176" : {
+      "value" : "176",
+      "label" : "Juuka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "177" : {
+      "value" : "177",
+      "label" : "Juupajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "178" : {
+      "value" : "178",
+      "label" : "Juva",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "179" : {
+      "value" : "179",
+      "label" : "Jyväskylä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "181" : {
+      "value" : "181",
+      "label" : "Jämijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "182" : {
+      "value" : "182",
+      "label" : "Jämsä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "186" : {
+      "value" : "186",
+      "label" : "Järvenpää",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "202" : {
+      "value" : "202",
+      "label" : "Kaarina",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "204" : {
+      "value" : "204",
+      "label" : "Kaavi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "205" : {
+      "value" : "205",
+      "label" : "Kajaani",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "208" : {
+      "value" : "208",
+      "label" : "Kalajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "211" : {
+      "value" : "211",
+      "label" : "Kangasala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "213" : {
+      "value" : "213",
+      "label" : "Kangasniemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "214" : {
+      "value" : "214",
+      "label" : "Kankaanpää",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "216" : {
+      "value" : "216",
+      "label" : "Kannonkoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "217" : {
+      "value" : "217",
+      "label" : "Kannus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "218" : {
+      "value" : "218",
+      "label" : "Karijoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "224" : {
+      "value" : "224",
+      "label" : "Karkkila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "226" : {
+      "value" : "226",
+      "label" : "Karstula",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "230" : {
+      "value" : "230",
+      "label" : "Karvia",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "231" : {
+      "value" : "231",
+      "label" : "Kaskinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "232" : {
+      "value" : "232",
+      "label" : "Kauhajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "233" : {
+      "value" : "233",
+      "label" : "Kauhava",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "235" : {
+      "value" : "235",
+      "label" : "Kauniainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "236" : {
+      "value" : "236",
+      "label" : "Kaustinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "239" : {
+      "value" : "239",
+      "label" : "Keitele",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "240" : {
+      "value" : "240",
+      "label" : "Kemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "241" : {
+      "value" : "241",
+      "label" : "Keminmaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "244" : {
+      "value" : "244",
+      "label" : "Kempele",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "245" : {
+      "value" : "245",
+      "label" : "Kerava",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "249" : {
+      "value" : "249",
+      "label" : "Keuruu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "250" : {
+      "value" : "250",
+      "label" : "Kihniö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "256" : {
+      "value" : "256",
+      "label" : "Kinnula",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "257" : {
+      "value" : "257",
+      "label" : "Kirkkonummi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "260" : {
+      "value" : "260",
+      "label" : "Kitee",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "261" : {
+      "value" : "261",
+      "label" : "Kittilä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "263" : {
+      "value" : "263",
+      "label" : "Kiuruvesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "265" : {
+      "value" : "265",
+      "label" : "Kivijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "271" : {
+      "value" : "271",
+      "label" : "Kokemäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "272" : {
+      "value" : "272",
+      "label" : "Kokkola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "273" : {
+      "value" : "273",
+      "label" : "Kolari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "275" : {
+      "value" : "275",
+      "label" : "Konnevesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "276" : {
+      "value" : "276",
+      "label" : "Kontiolahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "280" : {
+      "value" : "280",
+      "label" : "Korsnäs",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "284" : {
+      "value" : "284",
+      "label" : "Koski Tl",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "285" : {
+      "value" : "285",
+      "label" : "Kotka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "286" : {
+      "value" : "286",
+      "label" : "Kouvola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "287" : {
+      "value" : "287",
+      "label" : "Kristiinankaupunki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "288" : {
+      "value" : "288",
+      "label" : "Kruunupyy",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "290" : {
+      "value" : "290",
+      "label" : "Kuhmo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "291" : {
+      "value" : "291",
+      "label" : "Kuhmoinen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "295" : {
+      "value" : "295",
+      "label" : "Kumlinge",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "297" : {
+      "value" : "297",
+      "label" : "Kuopio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "300" : {
+      "value" : "300",
+      "label" : "Kuortane",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "301" : {
+      "value" : "301",
+      "label" : "Kurikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "304" : {
+      "value" : "304",
+      "label" : "Kustavi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "305" : {
+      "value" : "305",
+      "label" : "Kuusamo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "309" : {
+      "value" : "309",
+      "label" : "Outokumpu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "312" : {
+      "value" : "312",
+      "label" : "Kyyjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "316" : {
+      "value" : "316",
+      "label" : "Kärkölä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "317" : {
+      "value" : "317",
+      "label" : "Kärsämäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "318" : {
+      "value" : "318",
+      "label" : "Kökar",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "320" : {
+      "value" : "320",
+      "label" : "Kemijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "322" : {
+      "value" : "322",
+      "label" : "Kemiönsaari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "398" : {
+      "value" : "398",
+      "label" : "Lahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "399" : {
+      "value" : "399",
+      "label" : "Laihia",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "400" : {
+      "value" : "400",
+      "label" : "Laitila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "402" : {
+      "value" : "402",
+      "label" : "Lapinlahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "403" : {
+      "value" : "403",
+      "label" : "Lappajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "405" : {
+      "value" : "405",
+      "label" : "Lappeenranta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "407" : {
+      "value" : "407",
+      "label" : "Lapinjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "408" : {
+      "value" : "408",
+      "label" : "Lapua",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "410" : {
+      "value" : "410",
+      "label" : "Laukaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "416" : {
+      "value" : "416",
+      "label" : "Lemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "417" : {
+      "value" : "417",
+      "label" : "Lemland",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "418" : {
+      "value" : "418",
+      "label" : "Lempäälä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "420" : {
+      "value" : "420",
+      "label" : "Leppävirta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "421" : {
+      "value" : "421",
+      "label" : "Lestijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "422" : {
+      "value" : "422",
+      "label" : "Lieksa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "423" : {
+      "value" : "423",
+      "label" : "Lieto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "425" : {
+      "value" : "425",
+      "label" : "Liminka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "426" : {
+      "value" : "426",
+      "label" : "Liperi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "430" : {
+      "value" : "430",
+      "label" : "Loimaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "433" : {
+      "value" : "433",
+      "label" : "Loppi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "434" : {
+      "value" : "434",
+      "label" : "Loviisa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "435" : {
+      "value" : "435",
+      "label" : "Luhanka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "436" : {
+      "value" : "436",
+      "label" : "Lumijoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "438" : {
+      "value" : "438",
+      "label" : "Lumparland",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "440" : {
+      "value" : "440",
+      "label" : "Luoto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "441" : {
+      "value" : "441",
+      "label" : "Luumäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "444" : {
+      "value" : "444",
+      "label" : "Lohja",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "445" : {
+      "value" : "445",
+      "label" : "Parainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "475" : {
+      "value" : "475",
+      "label" : "Maalahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "478" : {
+      "value" : "478",
+      "label" : "Maarianhamina",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "480" : {
+      "value" : "480",
+      "label" : "Marttila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "481" : {
+      "value" : "481",
+      "label" : "Masku",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "483" : {
+      "value" : "483",
+      "label" : "Merijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "484" : {
+      "value" : "484",
+      "label" : "Merikarvia",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "489" : {
+      "value" : "489",
+      "label" : "Miehikkälä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "491" : {
+      "value" : "491",
+      "label" : "Mikkeli",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "494" : {
+      "value" : "494",
+      "label" : "Muhos",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "495" : {
+      "value" : "495",
+      "label" : "Multia",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "498" : {
+      "value" : "498",
+      "label" : "Muonio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "499" : {
+      "value" : "499",
+      "label" : "Mustasaari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "500" : {
+      "value" : "500",
+      "label" : "Muurame",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "503" : {
+      "value" : "503",
+      "label" : "Mynämäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "504" : {
+      "value" : "504",
+      "label" : "Myrskylä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "505" : {
+      "value" : "505",
+      "label" : "Mäntsälä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "507" : {
+      "value" : "507",
+      "label" : "Mäntyharju",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "508" : {
+      "value" : "508",
+      "label" : "Mänttä-Vilppula",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "529" : {
+      "value" : "529",
+      "label" : "Naantali",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "531" : {
+      "value" : "531",
+      "label" : "Nakkila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "535" : {
+      "value" : "535",
+      "label" : "Nivala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "536" : {
+      "value" : "536",
+      "label" : "Nokia",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "538" : {
+      "value" : "538",
+      "label" : "Nousiainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "541" : {
+      "value" : "541",
+      "label" : "Nurmes",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "543" : {
+      "value" : "543",
+      "label" : "Nurmijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "545" : {
+      "value" : "545",
+      "label" : "Närpiö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "560" : {
+      "value" : "560",
+      "label" : "Orimattila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "561" : {
+      "value" : "561",
+      "label" : "Oripää",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "562" : {
+      "value" : "562",
+      "label" : "Orivesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "563" : {
+      "value" : "563",
+      "label" : "Oulainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "564" : {
+      "value" : "564",
+      "label" : "Oulu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "576" : {
+      "value" : "576",
+      "label" : "Padasjoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "577" : {
+      "value" : "577",
+      "label" : "Paimio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "578" : {
+      "value" : "578",
+      "label" : "Paltamo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "580" : {
+      "value" : "580",
+      "label" : "Parikkala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "581" : {
+      "value" : "581",
+      "label" : "Parkano",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "583" : {
+      "value" : "583",
+      "label" : "Pelkosenniemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "584" : {
+      "value" : "584",
+      "label" : "Perho",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "588" : {
+      "value" : "588",
+      "label" : "Pertunmaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "592" : {
+      "value" : "592",
+      "label" : "Petäjävesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "593" : {
+      "value" : "593",
+      "label" : "Pieksämäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "595" : {
+      "value" : "595",
+      "label" : "Pielavesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "598" : {
+      "value" : "598",
+      "label" : "Pietarsaari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "599" : {
+      "value" : "599",
+      "label" : "Pedersören kunta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "601" : {
+      "value" : "601",
+      "label" : "Pihtipudas",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "604" : {
+      "value" : "604",
+      "label" : "Pirkkala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "607" : {
+      "value" : "607",
+      "label" : "Polvijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "608" : {
+      "value" : "608",
+      "label" : "Pomarkku",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "609" : {
+      "value" : "609",
+      "label" : "Pori",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "611" : {
+      "value" : "611",
+      "label" : "Pornainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "614" : {
+      "value" : "614",
+      "label" : "Posio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "615" : {
+      "value" : "615",
+      "label" : "Pudasjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "616" : {
+      "value" : "616",
+      "label" : "Pukkila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "619" : {
+      "value" : "619",
+      "label" : "Punkalaidun",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "620" : {
+      "value" : "620",
+      "label" : "Puolanka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "623" : {
+      "value" : "623",
+      "label" : "Puumala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "624" : {
+      "value" : "624",
+      "label" : "Pyhtää",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "625" : {
+      "value" : "625",
+      "label" : "Pyhäjoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "626" : {
+      "value" : "626",
+      "label" : "Pyhäjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "630" : {
+      "value" : "630",
+      "label" : "Pyhäntä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "631" : {
+      "value" : "631",
+      "label" : "Pyhäranta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "635" : {
+      "value" : "635",
+      "label" : "Pälkäne",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "636" : {
+      "value" : "636",
+      "label" : "Pöytyä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "638" : {
+      "value" : "638",
+      "label" : "Porvoo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "678" : {
+      "value" : "678",
+      "label" : "Raahe",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "680" : {
+      "value" : "680",
+      "label" : "Raisio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "681" : {
+      "value" : "681",
+      "label" : "Rantasalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "683" : {
+      "value" : "683",
+      "label" : "Ranua",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "684" : {
+      "value" : "684",
+      "label" : "Rauma",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "686" : {
+      "value" : "686",
+      "label" : "Rautalampi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "687" : {
+      "value" : "687",
+      "label" : "Rautavaara",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "689" : {
+      "value" : "689",
+      "label" : "Rautjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "691" : {
+      "value" : "691",
+      "label" : "Reisjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "694" : {
+      "value" : "694",
+      "label" : "Riihimäki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "697" : {
+      "value" : "697",
+      "label" : "Ristijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "698" : {
+      "value" : "698",
+      "label" : "Rovaniemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "700" : {
+      "value" : "700",
+      "label" : "Ruokolahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "702" : {
+      "value" : "702",
+      "label" : "Ruovesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "704" : {
+      "value" : "704",
+      "label" : "Rusko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "707" : {
+      "value" : "707",
+      "label" : "Rääkkylä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "710" : {
+      "value" : "710",
+      "label" : "Raasepori",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "729" : {
+      "value" : "729",
+      "label" : "Saarijärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "732" : {
+      "value" : "732",
+      "label" : "Salla",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "734" : {
+      "value" : "734",
+      "label" : "Salo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "736" : {
+      "value" : "736",
+      "label" : "Saltvik",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "738" : {
+      "value" : "738",
+      "label" : "Sauvo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "739" : {
+      "value" : "739",
+      "label" : "Savitaipale",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "740" : {
+      "value" : "740",
+      "label" : "Savonlinna",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "742" : {
+      "value" : "742",
+      "label" : "Savukoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "743" : {
+      "value" : "743",
+      "label" : "Seinäjoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "746" : {
+      "value" : "746",
+      "label" : "Sievi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "747" : {
+      "value" : "747",
+      "label" : "Siikainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "748" : {
+      "value" : "748",
+      "label" : "Siikajoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "749" : {
+      "value" : "749",
+      "label" : "Siilinjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "751" : {
+      "value" : "751",
+      "label" : "Simo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "753" : {
+      "value" : "753",
+      "label" : "Sipoo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "755" : {
+      "value" : "755",
+      "label" : "Siuntio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "758" : {
+      "value" : "758",
+      "label" : "Sodankylä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "759" : {
+      "value" : "759",
+      "label" : "Soini",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "761" : {
+      "value" : "761",
+      "label" : "Somero",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "762" : {
+      "value" : "762",
+      "label" : "Sonkajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "765" : {
+      "value" : "765",
+      "label" : "Sotkamo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "766" : {
+      "value" : "766",
+      "label" : "Sottunga",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "768" : {
+      "value" : "768",
+      "label" : "Sulkava",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "771" : {
+      "value" : "771",
+      "label" : "Sund",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "777" : {
+      "value" : "777",
+      "label" : "Suomussalmi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "778" : {
+      "value" : "778",
+      "label" : "Suonenjoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "781" : {
+      "value" : "781",
+      "label" : "Sysmä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "783" : {
+      "value" : "783",
+      "label" : "Säkylä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "785" : {
+      "value" : "785",
+      "label" : "Vaala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "790" : {
+      "value" : "790",
+      "label" : "Sastamala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "791" : {
+      "value" : "791",
+      "label" : "Siikalatva",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "831" : {
+      "value" : "831",
+      "label" : "Taipalsaari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "832" : {
+      "value" : "832",
+      "label" : "Taivalkoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "833" : {
+      "value" : "833",
+      "label" : "Taivassalo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "834" : {
+      "value" : "834",
+      "label" : "Tammela",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "837" : {
+      "value" : "837",
+      "label" : "Tampere",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "844" : {
+      "value" : "844",
+      "label" : "Tervo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "845" : {
+      "value" : "845",
+      "label" : "Tervola",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "846" : {
+      "value" : "846",
+      "label" : "Teuva",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "848" : {
+      "value" : "848",
+      "label" : "Tohmajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "849" : {
+      "value" : "849",
+      "label" : "Toholampi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "850" : {
+      "value" : "850",
+      "label" : "Toivakka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "851" : {
+      "value" : "851",
+      "label" : "Tornio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "853" : {
+      "value" : "853",
+      "label" : "Turku",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "854" : {
+      "value" : "854",
+      "label" : "Pello",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "857" : {
+      "value" : "857",
+      "label" : "Tuusniemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "858" : {
+      "value" : "858",
+      "label" : "Tuusula",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "859" : {
+      "value" : "859",
+      "label" : "Tyrnävä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "886" : {
+      "value" : "886",
+      "label" : "Ulvila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "887" : {
+      "value" : "887",
+      "label" : "Urjala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "889" : {
+      "value" : "889",
+      "label" : "Utajärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "890" : {
+      "value" : "890",
+      "label" : "Utsjoki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "892" : {
+      "value" : "892",
+      "label" : "Uurainen",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "893" : {
+      "value" : "893",
+      "label" : "Uusikaarlepyy",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "895" : {
+      "value" : "895",
+      "label" : "Uusikaupunki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "905" : {
+      "value" : "905",
+      "label" : "Vaasa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "908" : {
+      "value" : "908",
+      "label" : "Valkeakoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "915" : {
+      "value" : "915",
+      "label" : "Varkaus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "918" : {
+      "value" : "918",
+      "label" : "Vehmaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "921" : {
+      "value" : "921",
+      "label" : "Vesanto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "922" : {
+      "value" : "922",
+      "label" : "Vesilahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "924" : {
+      "value" : "924",
+      "label" : "Veteli",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "925" : {
+      "value" : "925",
+      "label" : "Vieremä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "927" : {
+      "value" : "927",
+      "label" : "Vihti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "931" : {
+      "value" : "931",
+      "label" : "Viitasaari",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "934" : {
+      "value" : "934",
+      "label" : "Vimpeli",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "935" : {
+      "value" : "935",
+      "label" : "Virolahti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "936" : {
+      "value" : "936",
+      "label" : "Virrat",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "941" : {
+      "value" : "941",
+      "label" : "Vårdö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "946" : {
+      "value" : "946",
+      "label" : "Vöyri",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "976" : {
+      "value" : "976",
+      "label" : "Ylitornio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "977" : {
+      "value" : "977",
+      "label" : "Ylivieska",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "980" : {
+      "value" : "980",
+      "label" : "Ylöjärvi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "981" : {
+      "value" : "981",
+      "label" : "Ypäjä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "989" : {
+      "value" : "989",
+      "label" : "Ähtäri",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "992" : {
+      "value" : "992",
+      "label" : "Äänekoski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_swe.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_municipality_swe.json
@@ -1,0 +1,2478 @@
+{
+  "name" : "municipality",
+  "values" : {
+    "005" : {
+      "value" : "005",
+      "label" : "Alajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "009" : {
+      "value" : "009",
+      "label" : "Alavieska",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "010" : {
+      "value" : "010",
+      "label" : "Alavus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "016" : {
+      "value" : "016",
+      "label" : "Asikkala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "018" : {
+      "value" : "018",
+      "label" : "Askola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "019" : {
+      "value" : "019",
+      "label" : "Aura",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "020" : {
+      "value" : "020",
+      "label" : "Akaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "035" : {
+      "value" : "035",
+      "label" : "Brändö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "043" : {
+      "value" : "043",
+      "label" : "Eckerö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "046" : {
+      "value" : "046",
+      "label" : "Enonkoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "047" : {
+      "value" : "047",
+      "label" : "Enontekis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "049" : {
+      "value" : "049",
+      "label" : "Esbo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "050" : {
+      "value" : "050",
+      "label" : "Eura",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "051" : {
+      "value" : "051",
+      "label" : "Euraåminne",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "052" : {
+      "value" : "052",
+      "label" : "Evijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "060" : {
+      "value" : "060",
+      "label" : "Finström",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "061" : {
+      "value" : "061",
+      "label" : "Forssa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "062" : {
+      "value" : "062",
+      "label" : "Föglö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "065" : {
+      "value" : "065",
+      "label" : "Geta",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "069" : {
+      "value" : "069",
+      "label" : "Haapajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "071" : {
+      "value" : "071",
+      "label" : "Haapavesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "072" : {
+      "value" : "072",
+      "label" : "Karlö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "074" : {
+      "value" : "074",
+      "label" : "Halsua",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "075" : {
+      "value" : "075",
+      "label" : "Fredrikshamn",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "076" : {
+      "value" : "076",
+      "label" : "Hammarland",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "077" : {
+      "value" : "077",
+      "label" : "Hankasalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "078" : {
+      "value" : "078",
+      "label" : "Hangö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "079" : {
+      "value" : "079",
+      "label" : "Harjavalta",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "081" : {
+      "value" : "081",
+      "label" : "Hartola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "082" : {
+      "value" : "082",
+      "label" : "Hattula",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "086" : {
+      "value" : "086",
+      "label" : "Hausjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "090" : {
+      "value" : "090",
+      "label" : "Heinävesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "091" : {
+      "value" : "091",
+      "label" : "Helsingfors",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "092" : {
+      "value" : "092",
+      "label" : "Vanda",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "097" : {
+      "value" : "097",
+      "label" : "Hirvensalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "098" : {
+      "value" : "098",
+      "label" : "Hollola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "102" : {
+      "value" : "102",
+      "label" : "Huittinen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "103" : {
+      "value" : "103",
+      "label" : "Humppila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "105" : {
+      "value" : "105",
+      "label" : "Hyrynsalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "106" : {
+      "value" : "106",
+      "label" : "Hyvinge",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "108" : {
+      "value" : "108",
+      "label" : "Tavastkyro",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "109" : {
+      "value" : "109",
+      "label" : "Tavastehus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "111" : {
+      "value" : "111",
+      "label" : "Heinola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "139" : {
+      "value" : "139",
+      "label" : "Ii",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "140" : {
+      "value" : "140",
+      "label" : "Idensalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "142" : {
+      "value" : "142",
+      "label" : "Iitti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "143" : {
+      "value" : "143",
+      "label" : "Ikalis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "145" : {
+      "value" : "145",
+      "label" : "Ilmajoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "146" : {
+      "value" : "146",
+      "label" : "Ilomants",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "148" : {
+      "value" : "148",
+      "label" : "Enare",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "149" : {
+      "value" : "149",
+      "label" : "Ingå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "151" : {
+      "value" : "151",
+      "label" : "Storå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "152" : {
+      "value" : "152",
+      "label" : "Storkyro",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "153" : {
+      "value" : "153",
+      "label" : "Imatra",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "165" : {
+      "value" : "165",
+      "label" : "Janakkala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "167" : {
+      "value" : "167",
+      "label" : "Joensuu",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "169" : {
+      "value" : "169",
+      "label" : "Jockis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "170" : {
+      "value" : "170",
+      "label" : "Jomala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "171" : {
+      "value" : "171",
+      "label" : "Jorois",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "172" : {
+      "value" : "172",
+      "label" : "Joutsa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "176" : {
+      "value" : "176",
+      "label" : "Juuka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "177" : {
+      "value" : "177",
+      "label" : "Juupajoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "178" : {
+      "value" : "178",
+      "label" : "Juva",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "179" : {
+      "value" : "179",
+      "label" : "Jyväskylä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "181" : {
+      "value" : "181",
+      "label" : "Jämijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "182" : {
+      "value" : "182",
+      "label" : "Jämsä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "186" : {
+      "value" : "186",
+      "label" : "Träskända",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "202" : {
+      "value" : "202",
+      "label" : "S:t Karins",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "204" : {
+      "value" : "204",
+      "label" : "Kaavi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "205" : {
+      "value" : "205",
+      "label" : "Kajana",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "208" : {
+      "value" : "208",
+      "label" : "Kalajoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "211" : {
+      "value" : "211",
+      "label" : "Kangasala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "213" : {
+      "value" : "213",
+      "label" : "Kangasniemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "214" : {
+      "value" : "214",
+      "label" : "Kankaanpää",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "216" : {
+      "value" : "216",
+      "label" : "Kannonkoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "217" : {
+      "value" : "217",
+      "label" : "Kannus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "218" : {
+      "value" : "218",
+      "label" : "Bötom",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "224" : {
+      "value" : "224",
+      "label" : "Högfors",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "226" : {
+      "value" : "226",
+      "label" : "Karstula",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "230" : {
+      "value" : "230",
+      "label" : "Karvia",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "231" : {
+      "value" : "231",
+      "label" : "Kaskö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "232" : {
+      "value" : "232",
+      "label" : "Kauhajoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "233" : {
+      "value" : "233",
+      "label" : "Kauhava",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "235" : {
+      "value" : "235",
+      "label" : "Grankulla",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "236" : {
+      "value" : "236",
+      "label" : "Kaustby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "239" : {
+      "value" : "239",
+      "label" : "Keitele",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "240" : {
+      "value" : "240",
+      "label" : "Kemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "241" : {
+      "value" : "241",
+      "label" : "Keminmaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "244" : {
+      "value" : "244",
+      "label" : "Kempele",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "245" : {
+      "value" : "245",
+      "label" : "Kervo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "249" : {
+      "value" : "249",
+      "label" : "Keuruu",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "250" : {
+      "value" : "250",
+      "label" : "Kihniö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "256" : {
+      "value" : "256",
+      "label" : "Kinnula",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "257" : {
+      "value" : "257",
+      "label" : "Kyrkslätt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "260" : {
+      "value" : "260",
+      "label" : "Kitee",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "261" : {
+      "value" : "261",
+      "label" : "Kittilä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "263" : {
+      "value" : "263",
+      "label" : "Kiuruvesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "265" : {
+      "value" : "265",
+      "label" : "Kivijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "271" : {
+      "value" : "271",
+      "label" : "Kumo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "272" : {
+      "value" : "272",
+      "label" : "Karleby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "273" : {
+      "value" : "273",
+      "label" : "Kolari",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "275" : {
+      "value" : "275",
+      "label" : "Konnevesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "276" : {
+      "value" : "276",
+      "label" : "Kontiolahti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "280" : {
+      "value" : "280",
+      "label" : "Korsnäs",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "284" : {
+      "value" : "284",
+      "label" : "Koski Tl",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "285" : {
+      "value" : "285",
+      "label" : "Kotka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "286" : {
+      "value" : "286",
+      "label" : "Kouvola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "287" : {
+      "value" : "287",
+      "label" : "Kristinestad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "288" : {
+      "value" : "288",
+      "label" : "Kronoby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "290" : {
+      "value" : "290",
+      "label" : "Kuhmo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "291" : {
+      "value" : "291",
+      "label" : "Kuhmoinen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "295" : {
+      "value" : "295",
+      "label" : "Kumlinge",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "297" : {
+      "value" : "297",
+      "label" : "Kuopio",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "300" : {
+      "value" : "300",
+      "label" : "Kuortane",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "301" : {
+      "value" : "301",
+      "label" : "Kurikka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "304" : {
+      "value" : "304",
+      "label" : "Gustavs",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "305" : {
+      "value" : "305",
+      "label" : "Kuusamo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "309" : {
+      "value" : "309",
+      "label" : "Outokumpu",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "312" : {
+      "value" : "312",
+      "label" : "Kyyjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "316" : {
+      "value" : "316",
+      "label" : "Kärkölä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "317" : {
+      "value" : "317",
+      "label" : "Kärsämäki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "318" : {
+      "value" : "318",
+      "label" : "Kökar",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "320" : {
+      "value" : "320",
+      "label" : "Kemijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "322" : {
+      "value" : "322",
+      "label" : "Kimitoön",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "398" : {
+      "value" : "398",
+      "label" : "Lahtis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "399" : {
+      "value" : "399",
+      "label" : "Laihela",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "400" : {
+      "value" : "400",
+      "label" : "Laitila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "402" : {
+      "value" : "402",
+      "label" : "Lapinlahti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "403" : {
+      "value" : "403",
+      "label" : "Lappajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "405" : {
+      "value" : "405",
+      "label" : "Villmanstrand",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "407" : {
+      "value" : "407",
+      "label" : "Lappträsk",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "408" : {
+      "value" : "408",
+      "label" : "Lappo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "410" : {
+      "value" : "410",
+      "label" : "Laukaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "416" : {
+      "value" : "416",
+      "label" : "Lemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "417" : {
+      "value" : "417",
+      "label" : "Lemland",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "418" : {
+      "value" : "418",
+      "label" : "Lempäälä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "420" : {
+      "value" : "420",
+      "label" : "Leppävirta",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "421" : {
+      "value" : "421",
+      "label" : "Lestijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "422" : {
+      "value" : "422",
+      "label" : "Lieksa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "423" : {
+      "value" : "423",
+      "label" : "Lundo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "425" : {
+      "value" : "425",
+      "label" : "Limingo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "426" : {
+      "value" : "426",
+      "label" : "Liperi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "430" : {
+      "value" : "430",
+      "label" : "Loimaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "433" : {
+      "value" : "433",
+      "label" : "Loppi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "434" : {
+      "value" : "434",
+      "label" : "Lovisa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "435" : {
+      "value" : "435",
+      "label" : "Luhanka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "436" : {
+      "value" : "436",
+      "label" : "Lumijoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "438" : {
+      "value" : "438",
+      "label" : "Lumparland",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "440" : {
+      "value" : "440",
+      "label" : "Larsmo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "441" : {
+      "value" : "441",
+      "label" : "Luumäki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "444" : {
+      "value" : "444",
+      "label" : "Lojo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "445" : {
+      "value" : "445",
+      "label" : "Pargas",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "475" : {
+      "value" : "475",
+      "label" : "Malax",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "478" : {
+      "value" : "478",
+      "label" : "Mariehamn",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "480" : {
+      "value" : "480",
+      "label" : "Marttila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "481" : {
+      "value" : "481",
+      "label" : "Masku",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "483" : {
+      "value" : "483",
+      "label" : "Merijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "484" : {
+      "value" : "484",
+      "label" : "Sastmola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "489" : {
+      "value" : "489",
+      "label" : "Miehikkälä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "491" : {
+      "value" : "491",
+      "label" : "S:t Michel",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "494" : {
+      "value" : "494",
+      "label" : "Muhos",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "495" : {
+      "value" : "495",
+      "label" : "Multia",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "498" : {
+      "value" : "498",
+      "label" : "Muonio",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "499" : {
+      "value" : "499",
+      "label" : "Korsholm",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "500" : {
+      "value" : "500",
+      "label" : "Muurame",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "503" : {
+      "value" : "503",
+      "label" : "Mynämäki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "504" : {
+      "value" : "504",
+      "label" : "Mörskom",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "505" : {
+      "value" : "505",
+      "label" : "Mäntsälä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "507" : {
+      "value" : "507",
+      "label" : "Mäntyharju",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "508" : {
+      "value" : "508",
+      "label" : "Mänttä-Vilppula",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "529" : {
+      "value" : "529",
+      "label" : "Nådendal",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "531" : {
+      "value" : "531",
+      "label" : "Nakkila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "535" : {
+      "value" : "535",
+      "label" : "Nivala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "536" : {
+      "value" : "536",
+      "label" : "Nokia",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "538" : {
+      "value" : "538",
+      "label" : "Nousis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "541" : {
+      "value" : "541",
+      "label" : "Nurmes",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "543" : {
+      "value" : "543",
+      "label" : "Nurmijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "545" : {
+      "value" : "545",
+      "label" : "Närpes",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "560" : {
+      "value" : "560",
+      "label" : "Orimattila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "561" : {
+      "value" : "561",
+      "label" : "Oripää",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "562" : {
+      "value" : "562",
+      "label" : "Orivesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "563" : {
+      "value" : "563",
+      "label" : "Oulainen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "564" : {
+      "value" : "564",
+      "label" : "Uleåborg",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "576" : {
+      "value" : "576",
+      "label" : "Padasjoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "577" : {
+      "value" : "577",
+      "label" : "Pemar",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "578" : {
+      "value" : "578",
+      "label" : "Paltamo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "580" : {
+      "value" : "580",
+      "label" : "Parikkala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "581" : {
+      "value" : "581",
+      "label" : "Parkano",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "583" : {
+      "value" : "583",
+      "label" : "Pelkosenniemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "584" : {
+      "value" : "584",
+      "label" : "Perho",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "588" : {
+      "value" : "588",
+      "label" : "Pertunmaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "592" : {
+      "value" : "592",
+      "label" : "Petäjävesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "593" : {
+      "value" : "593",
+      "label" : "Pieksämäki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "595" : {
+      "value" : "595",
+      "label" : "Pielavesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "598" : {
+      "value" : "598",
+      "label" : "Jakobstad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "599" : {
+      "value" : "599",
+      "label" : "Pedersöre",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "601" : {
+      "value" : "601",
+      "label" : "Pihtipudas",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "604" : {
+      "value" : "604",
+      "label" : "Birkala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "607" : {
+      "value" : "607",
+      "label" : "Polvijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "608" : {
+      "value" : "608",
+      "label" : "Påmark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "609" : {
+      "value" : "609",
+      "label" : "Björneborg",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "611" : {
+      "value" : "611",
+      "label" : "Borgnäs",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "614" : {
+      "value" : "614",
+      "label" : "Posio",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "615" : {
+      "value" : "615",
+      "label" : "Pudasjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "616" : {
+      "value" : "616",
+      "label" : "Pukkila",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "619" : {
+      "value" : "619",
+      "label" : "Punkalaidun",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "620" : {
+      "value" : "620",
+      "label" : "Puolanka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "623" : {
+      "value" : "623",
+      "label" : "Puumala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "624" : {
+      "value" : "624",
+      "label" : "Pyttis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "625" : {
+      "value" : "625",
+      "label" : "Pyhäjoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "626" : {
+      "value" : "626",
+      "label" : "Pyhäjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "630" : {
+      "value" : "630",
+      "label" : "Pyhäntä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "631" : {
+      "value" : "631",
+      "label" : "Pyhäranta",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "635" : {
+      "value" : "635",
+      "label" : "Pälkäne",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "636" : {
+      "value" : "636",
+      "label" : "Pöytyä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "638" : {
+      "value" : "638",
+      "label" : "Borgå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "678" : {
+      "value" : "678",
+      "label" : "Brahestad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "680" : {
+      "value" : "680",
+      "label" : "Reso",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "681" : {
+      "value" : "681",
+      "label" : "Rantasalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "683" : {
+      "value" : "683",
+      "label" : "Ranua",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "684" : {
+      "value" : "684",
+      "label" : "Raumo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "686" : {
+      "value" : "686",
+      "label" : "Rautalampi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "687" : {
+      "value" : "687",
+      "label" : "Rautavaara",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "689" : {
+      "value" : "689",
+      "label" : "Rautjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "691" : {
+      "value" : "691",
+      "label" : "Reisjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "694" : {
+      "value" : "694",
+      "label" : "Riihimäki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "697" : {
+      "value" : "697",
+      "label" : "Ristijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "698" : {
+      "value" : "698",
+      "label" : "Rovaniemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "700" : {
+      "value" : "700",
+      "label" : "Ruokolahti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "702" : {
+      "value" : "702",
+      "label" : "Ruovesi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "704" : {
+      "value" : "704",
+      "label" : "Rusko",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "707" : {
+      "value" : "707",
+      "label" : "Rääkkylä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "710" : {
+      "value" : "710",
+      "label" : "Raseborg",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "729" : {
+      "value" : "729",
+      "label" : "Saarijärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "732" : {
+      "value" : "732",
+      "label" : "Salla",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "734" : {
+      "value" : "734",
+      "label" : "Salo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "736" : {
+      "value" : "736",
+      "label" : "Saltvik",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "738" : {
+      "value" : "738",
+      "label" : "Sagu",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "739" : {
+      "value" : "739",
+      "label" : "Savitaipale",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "740" : {
+      "value" : "740",
+      "label" : "Nyslott",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "742" : {
+      "value" : "742",
+      "label" : "Savukoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "743" : {
+      "value" : "743",
+      "label" : "Seinäjoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "746" : {
+      "value" : "746",
+      "label" : "Sievi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "747" : {
+      "value" : "747",
+      "label" : "Siikainen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "748" : {
+      "value" : "748",
+      "label" : "Siikajoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "749" : {
+      "value" : "749",
+      "label" : "Siilinjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "751" : {
+      "value" : "751",
+      "label" : "Simo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "753" : {
+      "value" : "753",
+      "label" : "Sibbo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "755" : {
+      "value" : "755",
+      "label" : "Sjundeå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "758" : {
+      "value" : "758",
+      "label" : "Sodankylä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "759" : {
+      "value" : "759",
+      "label" : "Soini",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "761" : {
+      "value" : "761",
+      "label" : "Somero",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "762" : {
+      "value" : "762",
+      "label" : "Sonkajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "765" : {
+      "value" : "765",
+      "label" : "Sotkamo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "766" : {
+      "value" : "766",
+      "label" : "Sottunga",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "768" : {
+      "value" : "768",
+      "label" : "Sulkava",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "771" : {
+      "value" : "771",
+      "label" : "Sund",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "777" : {
+      "value" : "777",
+      "label" : "Suomussalmi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "778" : {
+      "value" : "778",
+      "label" : "Suonenjoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "781" : {
+      "value" : "781",
+      "label" : "Sysmä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "783" : {
+      "value" : "783",
+      "label" : "Säkylä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "785" : {
+      "value" : "785",
+      "label" : "Vaala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "790" : {
+      "value" : "790",
+      "label" : "Sastamala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "791" : {
+      "value" : "791",
+      "label" : "Siikalatva",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "831" : {
+      "value" : "831",
+      "label" : "Taipalsaari",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "832" : {
+      "value" : "832",
+      "label" : "Taivalkoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "833" : {
+      "value" : "833",
+      "label" : "Tövsala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "834" : {
+      "value" : "834",
+      "label" : "Tammela",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "837" : {
+      "value" : "837",
+      "label" : "Tammerfors",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "844" : {
+      "value" : "844",
+      "label" : "Tervo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "845" : {
+      "value" : "845",
+      "label" : "Tervola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "846" : {
+      "value" : "846",
+      "label" : "Östermark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "848" : {
+      "value" : "848",
+      "label" : "Tohmajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "849" : {
+      "value" : "849",
+      "label" : "Toholampi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "850" : {
+      "value" : "850",
+      "label" : "Toivakka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "851" : {
+      "value" : "851",
+      "label" : "Torneå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "853" : {
+      "value" : "853",
+      "label" : "Åbo",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "854" : {
+      "value" : "854",
+      "label" : "Pello",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "857" : {
+      "value" : "857",
+      "label" : "Tuusniemi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "858" : {
+      "value" : "858",
+      "label" : "Tusby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "859" : {
+      "value" : "859",
+      "label" : "Tyrnävä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "886" : {
+      "value" : "886",
+      "label" : "Ulvsby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "887" : {
+      "value" : "887",
+      "label" : "Urjala",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "889" : {
+      "value" : "889",
+      "label" : "Utajärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "890" : {
+      "value" : "890",
+      "label" : "Utsjoki",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "892" : {
+      "value" : "892",
+      "label" : "Uurainen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "893" : {
+      "value" : "893",
+      "label" : "Nykarleby",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "895" : {
+      "value" : "895",
+      "label" : "Nystad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "905" : {
+      "value" : "905",
+      "label" : "Vasa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "908" : {
+      "value" : "908",
+      "label" : "Valkeakoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "915" : {
+      "value" : "915",
+      "label" : "Varkaus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "918" : {
+      "value" : "918",
+      "label" : "Vehmaa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "921" : {
+      "value" : "921",
+      "label" : "Vesanto",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "922" : {
+      "value" : "922",
+      "label" : "Vesilahti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "924" : {
+      "value" : "924",
+      "label" : "Vetil",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "925" : {
+      "value" : "925",
+      "label" : "Vieremä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "927" : {
+      "value" : "927",
+      "label" : "Vichtis",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "931" : {
+      "value" : "931",
+      "label" : "Viitasaari",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "934" : {
+      "value" : "934",
+      "label" : "Vimpeli",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "935" : {
+      "value" : "935",
+      "label" : "Virolahti",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "936" : {
+      "value" : "936",
+      "label" : "Virdois",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "941" : {
+      "value" : "941",
+      "label" : "Vårdö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "946" : {
+      "value" : "946",
+      "label" : "Vörå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "976" : {
+      "value" : "976",
+      "label" : "Övertorneå",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "977" : {
+      "value" : "977",
+      "label" : "Ylivieska",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "980" : {
+      "value" : "980",
+      "label" : "Ylöjärvi",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "981" : {
+      "value" : "981",
+      "label" : "Ypäjä",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "989" : {
+      "value" : "989",
+      "label" : "Etseri",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    },
+    "992" : {
+      "value" : "992",
+      "label" : "Äänekoski",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "municipality",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_eng.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_eng.json
@@ -1,0 +1,1238 @@
+{
+  "name" : "placetype",
+  "values" : {
+    "0" : {
+      "value" : "0",
+      "label" : "Undefined object",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010105" : {
+      "value" : "1010105",
+      "label" : "Group of islands or islets",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010110" : {
+      "value" : "1010110",
+      "label" : "Island or islet",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010115" : {
+      "value" : "1010115",
+      "label" : "Boulder in water or boulders in water",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010120" : {
+      "value" : "1010120",
+      "label" : "Cape",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010125" : {
+      "value" : "1010125",
+      "label" : "Isthmus",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010130" : {
+      "value" : "1010130",
+      "label" : "Shore or waterside",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010205" : {
+      "value" : "1010205",
+      "label" : "Group of elevations",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010210" : {
+      "value" : "1010210",
+      "label" : "Elevation",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010305" : {
+      "value" : "1010305",
+      "label" : "Depression",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010405" : {
+      "value" : "1010405",
+      "label" : "Shallows",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010410" : {
+      "value" : "1010410",
+      "label" : "Deep",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020105" : {
+      "value" : "1020105",
+      "label" : "Forested area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020205" : {
+      "value" : "1020205",
+      "label" : "Marsh or paludified area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020305" : {
+      "value" : "1020305",
+      "label" : "Field",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020405" : {
+      "value" : "1020405",
+      "label" : "Meadow or pasture",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020410" : {
+      "value" : "1020410",
+      "label" : "Bushland",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020505" : {
+      "value" : "1020505",
+      "label" : "Blockfield or rocky area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030105" : {
+      "value" : "1030105",
+      "label" : "Boulder",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030110" : {
+      "value" : "1030110",
+      "label" : "Tree",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999905" : {
+      "value" : "1999905",
+      "label" : "Former dwelling place",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999999" : {
+      "value" : "1999999",
+      "label" : "Other terrain feature",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010105" : {
+      "value" : "2010105",
+      "label" : "Baltic sea and its main parts",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010110" : {
+      "value" : "2010110",
+      "label" : "Part of sea",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010205" : {
+      "value" : "2010205",
+      "label" : "Group of lakes or ponds",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010210" : {
+      "value" : "2010210",
+      "label" : "Lake or pond",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010215" : {
+      "value" : "2010215",
+      "label" : "Part of lake",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010220" : {
+      "value" : "2010220",
+      "label" : "Reservoir",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010225" : {
+      "value" : "2010225",
+      "label" : "Part of reservoir",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010230" : {
+      "value" : "2010230",
+      "label" : "Canal",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020105" : {
+      "value" : "2020105",
+      "label" : "Watercourse",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020110" : {
+      "value" : "2020110",
+      "label" : "Part of watercourse",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020115" : {
+      "value" : "2020115",
+      "label" : "Rapids",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030105" : {
+      "value" : "2030105",
+      "label" : "Spring",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030110" : {
+      "value" : "2030110",
+      "label" : "Water pit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2999999" : {
+      "value" : "2999999",
+      "label" : "Other water feature",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010105" : {
+      "value" : "3010105",
+      "label" : "City or town or population centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010110" : {
+      "value" : "3010110",
+      "label" : "Village or neighbourhood",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020105" : {
+      "value" : "3020105",
+      "label" : "Part of city or town or population centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020110" : {
+      "value" : "3020110",
+      "label" : "Park",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020115" : {
+      "value" : "3020115",
+      "label" : "Market place or square",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3030105" : {
+      "value" : "3030105",
+      "label" : "House",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3999999" : {
+      "value" : "3999999",
+      "label" : "Other populated place",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010105" : {
+      "value" : "4010105",
+      "label" : "State",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010110" : {
+      "value" : "4010110",
+      "label" : "Area of operation of the Regional State Administrative Agency",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010115" : {
+      "value" : "4010115",
+      "label" : "Area of operation of the Centre for Economic Development, Transport and the Environment",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010120" : {
+      "value" : "4010120",
+      "label" : "Region",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010125" : {
+      "value" : "4010125",
+      "label" : "Municipality",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010205" : {
+      "value" : "4010205",
+      "label" : "Boundary marker",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020105" : {
+      "value" : "4020105",
+      "label" : "Main office of the Regional State Administrative Agency",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020110" : {
+      "value" : "4020110",
+      "label" : "Main office of the Centre for Economic Development, Transport and the Environment",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020115" : {
+      "value" : "4020115",
+      "label" : "Office of the Regional Council",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020120" : {
+      "value" : "4020120",
+      "label" : "Municipal hall",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020199" : {
+      "value" : "4020199",
+      "label" : "Other administrative building or office",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030105" : {
+      "value" : "4030105",
+      "label" : "Church",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030110" : {
+      "value" : "4030110",
+      "label" : "Other holy building",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030199" : {
+      "value" : "4030199",
+      "label" : "Other religious building",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040105" : {
+      "value" : "4040105",
+      "label" : "Cemetery",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040199" : {
+      "value" : "4040199",
+      "label" : "Other burial service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050105" : {
+      "value" : "4050105",
+      "label" : "Hospital",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050199" : {
+      "value" : "4050199",
+      "label" : "Other health service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050299" : {
+      "value" : "4050299",
+      "label" : "Social care unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4059999" : {
+      "value" : "4059999",
+      "label" : "Other social or health service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060105" : {
+      "value" : "4060105",
+      "label" : "Fire station",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060110" : {
+      "value" : "4060110",
+      "label" : "Volunteer fire station",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060199" : {
+      "value" : "4060199",
+      "label" : "Other rescue service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060205" : {
+      "value" : "4060205",
+      "label" : "Police station",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060299" : {
+      "value" : "4060299",
+      "label" : "Other police unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060305" : {
+      "value" : "4060305",
+      "label" : "Prison",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060399" : {
+      "value" : "4060399",
+      "label" : "Other criminal sanctions unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060405" : {
+      "value" : "4060405",
+      "label" : "Customs office",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060499" : {
+      "value" : "4060499",
+      "label" : "Other customs unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060505" : {
+      "value" : "4060505",
+      "label" : "Military area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060599" : {
+      "value" : "4060599",
+      "label" : "Other defence forces unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060605" : {
+      "value" : "4060605",
+      "label" : "Border crossing point",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060699" : {
+      "value" : "4060699",
+      "label" : "Other border guard unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4069999" : {
+      "value" : "4069999",
+      "label" : "Other security or defence unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070105" : {
+      "value" : "4070105",
+      "label" : "University",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070199" : {
+      "value" : "4070199",
+      "label" : "Other educational unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070205" : {
+      "value" : "4070205",
+      "label" : "Research institute",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070299" : {
+      "value" : "4070299",
+      "label" : "Other research unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080105" : {
+      "value" : "4080105",
+      "label" : "Waste processing plant",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080199" : {
+      "value" : "4080199",
+      "label" : "Other waste management unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4999999" : {
+      "value" : "4999999",
+      "label" : "Other administrative unit or public service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010105" : {
+      "value" : "5010105",
+      "label" : "National park",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010110" : {
+      "value" : "5010110",
+      "label" : "Strict nature reserve",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010115" : {
+      "value" : "5010115",
+      "label" : "Other nature reserve",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999905" : {
+      "value" : "5999905",
+      "label" : "Wilderness area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999910" : {
+      "value" : "5999910",
+      "label" : "National hiking area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999915" : {
+      "value" : "5999915",
+      "label" : "World heritage site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999920" : {
+      "value" : "5999920",
+      "label" : "Natural monument",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999925" : {
+      "value" : "5999925",
+      "label" : "Ancient relic",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999999" : {
+      "value" : "5999999",
+      "label" : "Other protected site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010105" : {
+      "value" : "6010105",
+      "label" : "Bus station",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010110" : {
+      "value" : "6010110",
+      "label" : "Ferry or cable ferry",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010199" : {
+      "value" : "6010199",
+      "label" : "Other road transport site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010205" : {
+      "value" : "6010205",
+      "label" : "Railway station or stop",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010210" : {
+      "value" : "6010210",
+      "label" : "Metro station",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010299" : {
+      "value" : "6010299",
+      "label" : "Other rail transport site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010305" : {
+      "value" : "6010305",
+      "label" : "Harbour, port or haven",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010310" : {
+      "value" : "6010310",
+      "label" : "Lighthouse or aid to navigation",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010399" : {
+      "value" : "6010399",
+      "label" : "Other water transport site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010405" : {
+      "value" : "6010405",
+      "label" : "Airport or airfield",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010499" : {
+      "value" : "6010499",
+      "label" : "Other air transport site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010505" : {
+      "value" : "6010505",
+      "label" : "Data centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010599" : {
+      "value" : "6010599",
+      "label" : "Other telecommunication site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019905" : {
+      "value" : "6019905",
+      "label" : "Bridge",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019910" : {
+      "value" : "6019910",
+      "label" : "Tunnel",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019915" : {
+      "value" : "6019915",
+      "label" : "Transport terminal",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019999" : {
+      "value" : "6019999",
+      "label" : "Production, industry and commerce",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010199" : {
+      "value" : "7010199",
+      "label" : "Agricultural unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010299" : {
+      "value" : "7010299",
+      "label" : "Game and fisheries unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010305" : {
+      "value" : "7010305",
+      "label" : "Mine or quarry",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010310" : {
+      "value" : "7010310",
+      "label" : "Gravel or sand extraction area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010315" : {
+      "value" : "7010315",
+      "label" : "Peat production area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010399" : {
+      "value" : "7010399",
+      "label" : "Other mineral resources extraction area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010405" : {
+      "value" : "7010405",
+      "label" : "Industrial area",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010410" : {
+      "value" : "7010410",
+      "label" : "Factory",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010415" : {
+      "value" : "7010415",
+      "label" : "Dock",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010499" : {
+      "value" : "7010499",
+      "label" : "Other industrial unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010505" : {
+      "value" : "7010505",
+      "label" : "Power or heat plant",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010599" : {
+      "value" : "7010599",
+      "label" : "Other energy production unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7019999" : {
+      "value" : "7019999",
+      "label" : "Other production or industrial unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020105" : {
+      "value" : "7020105",
+      "label" : "Shopping centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020199" : {
+      "value" : "7020199",
+      "label" : "Other commercial centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7029999" : {
+      "value" : "7029999",
+      "label" : "Other commercial unit",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010105" : {
+      "value" : "8010105",
+      "label" : "Cultural or fair centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010110" : {
+      "value" : "8010110",
+      "label" : "Museum",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010115" : {
+      "value" : "8010115",
+      "label" : "Theatre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010120" : {
+      "value" : "8010120",
+      "label" : "Monument or work of art",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010199" : {
+      "value" : "8010199",
+      "label" : "Other cultural service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020105" : {
+      "value" : "8020105",
+      "label" : "Sports park",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020110" : {
+      "value" : "8020110",
+      "label" : "Sports field",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020115" : {
+      "value" : "8020115",
+      "label" : "Sports hall",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020120" : {
+      "value" : "8020120",
+      "label" : "Swimming pool",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020125" : {
+      "value" : "8020125",
+      "label" : "Golf course",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020130" : {
+      "value" : "8020130",
+      "label" : "Skiing centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020135" : {
+      "value" : "8020135",
+      "label" : "Shooting range",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020140" : {
+      "value" : "8020140",
+      "label" : "Motor racing track",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020145" : {
+      "value" : "8020145",
+      "label" : "Trotting track",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020199" : {
+      "value" : "8020199",
+      "label" : "Other sports or exercise site",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030105" : {
+      "value" : "8030105",
+      "label" : "Amusement park",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030110" : {
+      "value" : "8030110",
+      "label" : "Zoo",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030115" : {
+      "value" : "8030115",
+      "label" : "Swimming beach",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030120" : {
+      "value" : "8030120",
+      "label" : "Nature centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030125" : {
+      "value" : "8030125",
+      "label" : "Camp centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030130" : {
+      "value" : "8030130",
+      "label" : "Travel, hiking or holiday centre",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030135" : {
+      "value" : "8030135",
+      "label" : "Campsite",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030140" : {
+      "value" : "8030140",
+      "label" : "Allotment garden",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030145" : {
+      "value" : "8030145",
+      "label" : "Hiking route",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030150" : {
+      "value" : "8030150",
+      "label" : "Wilderness hut or daytrip hut or booked or rented hut",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030199" : {
+      "value" : "8030199",
+      "label" : "Other recreational service",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999905" : {
+      "value" : "9999905",
+      "label" : "Significant building",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999999" : {
+      "value" : "9999999",
+      "label" : "Other cultural object",
+      "status" : "valid",
+      "lang" : "eng",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_fin.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_fin.json
@@ -1,0 +1,1238 @@
+{
+  "name" : "placetype",
+  "values" : {
+    "0" : {
+      "value" : "0",
+      "label" : "Määrittelemätön kohde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010105" : {
+      "value" : "1010105",
+      "label" : "Saari- tai luotoryhmä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010110" : {
+      "value" : "1010110",
+      "label" : "Saari tai luoto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010115" : {
+      "value" : "1010115",
+      "label" : "Vesikivi tai -kivikko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010120" : {
+      "value" : "1010120",
+      "label" : "Niemi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010125" : {
+      "value" : "1010125",
+      "label" : "Kannas",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010130" : {
+      "value" : "1010130",
+      "label" : "Ranta-alue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010205" : {
+      "value" : "1010205",
+      "label" : "Kohoumaryhmä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010210" : {
+      "value" : "1010210",
+      "label" : "Kohouma",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010305" : {
+      "value" : "1010305",
+      "label" : "Painanne",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010405" : {
+      "value" : "1010405",
+      "label" : "Matalikko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010410" : {
+      "value" : "1010410",
+      "label" : "Syvänne",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020105" : {
+      "value" : "1020105",
+      "label" : "Metsäalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020205" : {
+      "value" : "1020205",
+      "label" : "Suo tai kosteikko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020305" : {
+      "value" : "1020305",
+      "label" : "Pelto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020405" : {
+      "value" : "1020405",
+      "label" : "Niitty tai laidun",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020410" : {
+      "value" : "1020410",
+      "label" : "Pensaikko tai varvikko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020505" : {
+      "value" : "1020505",
+      "label" : "Louhikko tai kivikko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030105" : {
+      "value" : "1030105",
+      "label" : "Kivi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030110" : {
+      "value" : "1030110",
+      "label" : "Puu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999905" : {
+      "value" : "1999905",
+      "label" : "Hävinnyt asuinpaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999999" : {
+      "value" : "1999999",
+      "label" : "Muu maastopaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010105" : {
+      "value" : "2010105",
+      "label" : "Itämeri ja sen pääosa-alueet",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010110" : {
+      "value" : "2010110",
+      "label" : "Merialueen osa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010205" : {
+      "value" : "2010205",
+      "label" : "Järvi- tai lampiryhmä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010210" : {
+      "value" : "2010210",
+      "label" : "Järvi tai lampi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010215" : {
+      "value" : "2010215",
+      "label" : "Järven osa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010220" : {
+      "value" : "2010220",
+      "label" : "Tekojärvi tai -lampi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010225" : {
+      "value" : "2010225",
+      "label" : "Tekojärven osa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010230" : {
+      "value" : "2010230",
+      "label" : "Kanava",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020105" : {
+      "value" : "2020105",
+      "label" : "Virtavesi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020110" : {
+      "value" : "2020110",
+      "label" : "Virtaveden osa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020115" : {
+      "value" : "2020115",
+      "label" : "Koski",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030105" : {
+      "value" : "2030105",
+      "label" : "Lähde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030110" : {
+      "value" : "2030110",
+      "label" : "Vesikuoppa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2999999" : {
+      "value" : "2999999",
+      "label" : "Muu vesipaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010105" : {
+      "value" : "3010105",
+      "label" : "Kaupunkialue tai taajama",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010110" : {
+      "value" : "3010110",
+      "label" : "Kylä tai kulmakunta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020105" : {
+      "value" : "3020105",
+      "label" : "Kaupunkialueen tai taajaman osa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020110" : {
+      "value" : "3020110",
+      "label" : "Puisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020115" : {
+      "value" : "3020115",
+      "label" : "Tori tai aukio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3030105" : {
+      "value" : "3030105",
+      "label" : "Talo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3999999" : {
+      "value" : "3999999",
+      "label" : "Muu asutuskohde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010105" : {
+      "value" : "4010105",
+      "label" : "Valtio",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010110" : {
+      "value" : "4010110",
+      "label" : "Aluehallintoviraston toimialue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010115" : {
+      "value" : "4010115",
+      "label" : "ELY-keskuksen toimialue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010120" : {
+      "value" : "4010120",
+      "label" : "Maakunta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010125" : {
+      "value" : "4010125",
+      "label" : "Kunta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010205" : {
+      "value" : "4010205",
+      "label" : "Rajapyykki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020105" : {
+      "value" : "4020105",
+      "label" : "Aluehallintoviraston päätoimipaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020110" : {
+      "value" : "4020110",
+      "label" : "ELY-keskuksen päätoimipaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020115" : {
+      "value" : "4020115",
+      "label" : "Maakunnan liiton toimisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020120" : {
+      "value" : "4020120",
+      "label" : "Kunnanvirasto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020199" : {
+      "value" : "4020199",
+      "label" : "Muu hallinnollinen rakennus tai toimipaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030105" : {
+      "value" : "4030105",
+      "label" : "Kirkko",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030110" : {
+      "value" : "4030110",
+      "label" : "Muu pyhä rakennus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030199" : {
+      "value" : "4030199",
+      "label" : "Muu uskonnollinen rakennus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040105" : {
+      "value" : "4040105",
+      "label" : "Hautausmaa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040199" : {
+      "value" : "4040199",
+      "label" : "Muu hautaustoimen yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050105" : {
+      "value" : "4050105",
+      "label" : "Sairaala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050199" : {
+      "value" : "4050199",
+      "label" : "Muu terveydenhuollon yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050299" : {
+      "value" : "4050299",
+      "label" : "Sosiaalihuollon yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4059999" : {
+      "value" : "4059999",
+      "label" : "Muu sosiaali- tai terveydenhuollon yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060105" : {
+      "value" : "4060105",
+      "label" : "Pelastus- tai paloasema",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060110" : {
+      "value" : "4060110",
+      "label" : "Vapaaehtoisen tai sopimuspalokunnan yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060199" : {
+      "value" : "4060199",
+      "label" : "Muu pelastustoimen yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060205" : {
+      "value" : "4060205",
+      "label" : "Poliisiasema",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060299" : {
+      "value" : "4060299",
+      "label" : "Muu poliisitoimen yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060305" : {
+      "value" : "4060305",
+      "label" : "Vankila",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060399" : {
+      "value" : "4060399",
+      "label" : "Muu rikosseuraamuslaitoksen yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060405" : {
+      "value" : "4060405",
+      "label" : "Tulliasema",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060499" : {
+      "value" : "4060499",
+      "label" : "Muu tullin yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060505" : {
+      "value" : "4060505",
+      "label" : "Sotilasalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060599" : {
+      "value" : "4060599",
+      "label" : "Muu puolustusvoimien yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060605" : {
+      "value" : "4060605",
+      "label" : "Rajanylityspaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060699" : {
+      "value" : "4060699",
+      "label" : "Muu rajavartiolaitoksen yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4069999" : {
+      "value" : "4069999",
+      "label" : "Muu turvallisuus- tai puolustusalan yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070105" : {
+      "value" : "4070105",
+      "label" : "Yliopisto tai korkeakoulu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070199" : {
+      "value" : "4070199",
+      "label" : "Muu koulutusyksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070205" : {
+      "value" : "4070205",
+      "label" : "Tutkimuslaitos",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070299" : {
+      "value" : "4070299",
+      "label" : "Muu tutkimusyksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080105" : {
+      "value" : "4080105",
+      "label" : "Jätteenkäsittelylaitos",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080199" : {
+      "value" : "4080199",
+      "label" : "Muu jätehuollon yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4999999" : {
+      "value" : "4999999",
+      "label" : "Muu hallinnon yksikkö tai julkinen palvelu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010105" : {
+      "value" : "5010105",
+      "label" : "Kansallispuisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010110" : {
+      "value" : "5010110",
+      "label" : "Luonnonpuisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010115" : {
+      "value" : "5010115",
+      "label" : "Muu luonnonsuojelualue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999905" : {
+      "value" : "5999905",
+      "label" : "Erämaa-alue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999910" : {
+      "value" : "5999910",
+      "label" : "Valtion retkeilyalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999915" : {
+      "value" : "5999915",
+      "label" : "Maailmanperintökohde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999920" : {
+      "value" : "5999920",
+      "label" : "Luonnonmuistomerkki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999925" : {
+      "value" : "5999925",
+      "label" : "Muinaisjäännös",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999999" : {
+      "value" : "5999999",
+      "label" : "Muu suojeltu kohde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010105" : {
+      "value" : "6010105",
+      "label" : "Linja-autoasema",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010110" : {
+      "value" : "6010110",
+      "label" : "Lautta tai lossi",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010199" : {
+      "value" : "6010199",
+      "label" : "Muu tieliikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010205" : {
+      "value" : "6010205",
+      "label" : "Rautatieasema tai seisake",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010210" : {
+      "value" : "6010210",
+      "label" : "Metroasema",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010299" : {
+      "value" : "6010299",
+      "label" : "Muu raideliikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010305" : {
+      "value" : "6010305",
+      "label" : "Satama",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010310" : {
+      "value" : "6010310",
+      "label" : "Majakka tai turvalaite",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010399" : {
+      "value" : "6010399",
+      "label" : "Muu vesiliikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010405" : {
+      "value" : "6010405",
+      "label" : "Lentoasema tai lentokenttä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010499" : {
+      "value" : "6010499",
+      "label" : "Muu ilmaliikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010505" : {
+      "value" : "6010505",
+      "label" : "Datakeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010599" : {
+      "value" : "6010599",
+      "label" : "Muu tietoliikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019905" : {
+      "value" : "6019905",
+      "label" : "Silta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019910" : {
+      "value" : "6019910",
+      "label" : "Tunneli",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019915" : {
+      "value" : "6019915",
+      "label" : "Liikenneterminaali",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019999" : {
+      "value" : "6019999",
+      "label" : "Muu liikennepaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010199" : {
+      "value" : "7010199",
+      "label" : "Maatalouden yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010299" : {
+      "value" : "7010299",
+      "label" : "Riista- tai kalatalouden yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010305" : {
+      "value" : "7010305",
+      "label" : "Kaivos tai louhos",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010310" : {
+      "value" : "7010310",
+      "label" : "Soran- tai hiekanottoalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010315" : {
+      "value" : "7010315",
+      "label" : "Turvetuotantoalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010399" : {
+      "value" : "7010399",
+      "label" : "Muu maa-aineksenottoalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010405" : {
+      "value" : "7010405",
+      "label" : "Teollisuusalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010410" : {
+      "value" : "7010410",
+      "label" : "Tehdas",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010415" : {
+      "value" : "7010415",
+      "label" : "Telakka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010499" : {
+      "value" : "7010499",
+      "label" : "Muu teollisuuden yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010505" : {
+      "value" : "7010505",
+      "label" : "Sähkön- tai lämmöntuotantolaitos",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010599" : {
+      "value" : "7010599",
+      "label" : "Muu energiatuotannon yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7019999" : {
+      "value" : "7019999",
+      "label" : "Muu tuotannon tai teollisuuden yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020105" : {
+      "value" : "7020105",
+      "label" : "Kauppakeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020199" : {
+      "value" : "7020199",
+      "label" : "Muu kauppakeskittymä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7029999" : {
+      "value" : "7029999",
+      "label" : "Muu kaupan yksikkö",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010105" : {
+      "value" : "8010105",
+      "label" : "Kulttuuri- tai messukeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010110" : {
+      "value" : "8010110",
+      "label" : "Museo",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010115" : {
+      "value" : "8010115",
+      "label" : "Teatteri",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010120" : {
+      "value" : "8010120",
+      "label" : "Muistomerkki",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010199" : {
+      "value" : "8010199",
+      "label" : "Muu kulttuuripalvelu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020105" : {
+      "value" : "8020105",
+      "label" : "Urheilupuisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020110" : {
+      "value" : "8020110",
+      "label" : "Urheilukenttä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020115" : {
+      "value" : "8020115",
+      "label" : "Urheiluhalli",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020120" : {
+      "value" : "8020120",
+      "label" : "Uimahalli tai uimala",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020125" : {
+      "value" : "8020125",
+      "label" : "Golfkenttä",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020130" : {
+      "value" : "8020130",
+      "label" : "Hiihto- tai laskettelukeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020135" : {
+      "value" : "8020135",
+      "label" : "Ampumarata",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020140" : {
+      "value" : "8020140",
+      "label" : "Moottorirata",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020145" : {
+      "value" : "8020145",
+      "label" : "Ravirata",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020199" : {
+      "value" : "8020199",
+      "label" : "Muu urheilu- tai liikuntapaikka",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030105" : {
+      "value" : "8030105",
+      "label" : "Huvipuisto",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030110" : {
+      "value" : "8030110",
+      "label" : "Eläintarha",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030115" : {
+      "value" : "8030115",
+      "label" : "Uimaranta",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030120" : {
+      "value" : "8030120",
+      "label" : "Luontokeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030125" : {
+      "value" : "8030125",
+      "label" : "Leirikeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030130" : {
+      "value" : "8030130",
+      "label" : "Matkailu-, retkeily- tai lomakeskus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030135" : {
+      "value" : "8030135",
+      "label" : "Leirintäalue",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030140" : {
+      "value" : "8030140",
+      "label" : "Siirtolapuutarha",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030145" : {
+      "value" : "8030145",
+      "label" : "Retkeilyreitti",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030150" : {
+      "value" : "8030150",
+      "label" : "Autio-, päivä-, varaus- tai vuokratupa",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030199" : {
+      "value" : "8030199",
+      "label" : "Muu virkistys- tai vapaa-ajan palvelu",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999905" : {
+      "value" : "9999905",
+      "label" : "Merkittävä rakennus",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999999" : {
+      "value" : "9999999",
+      "label" : "Muu kulttuurikohde",
+      "status" : "valid",
+      "lang" : "fin",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}

--- a/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_swe.json
+++ b/service-search-nls/src/main/resources/fi/nls/oskari/search/channel/OGC_API_SEARCH_CHANNEL_placetype_swe.json
@@ -1,0 +1,1238 @@
+{
+  "name" : "placetype",
+  "values" : {
+    "0" : {
+      "value" : "0",
+      "label" : "Odefinierat objekt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010105" : {
+      "value" : "1010105",
+      "label" : "Grupp av öar eller skär",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010110" : {
+      "value" : "1010110",
+      "label" : "Ö eller skär",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010115" : {
+      "value" : "1010115",
+      "label" : "Sten eller stenar i vatten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010120" : {
+      "value" : "1010120",
+      "label" : "Udde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010125" : {
+      "value" : "1010125",
+      "label" : "Näs",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010130" : {
+      "value" : "1010130",
+      "label" : "Strandområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010205" : {
+      "value" : "1010205",
+      "label" : "Grupp av höjningar",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010210" : {
+      "value" : "1010210",
+      "label" : "Höjning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010305" : {
+      "value" : "1010305",
+      "label" : "Sänka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010405" : {
+      "value" : "1010405",
+      "label" : "Grund",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1010410" : {
+      "value" : "1010410",
+      "label" : "Djup",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020105" : {
+      "value" : "1020105",
+      "label" : "Skogsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020205" : {
+      "value" : "1020205",
+      "label" : "Myr eller våtmark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020305" : {
+      "value" : "1020305",
+      "label" : "Åker",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020405" : {
+      "value" : "1020405",
+      "label" : "Äng eller betesmark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020410" : {
+      "value" : "1020410",
+      "label" : "Buskage eller rismark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1020505" : {
+      "value" : "1020505",
+      "label" : "Blockfält eller stenfält",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030105" : {
+      "value" : "1030105",
+      "label" : "Sten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1030110" : {
+      "value" : "1030110",
+      "label" : "Träd",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999905" : {
+      "value" : "1999905",
+      "label" : "Försvunnen boplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "1999999" : {
+      "value" : "1999999",
+      "label" : "Annan plats i terrängen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010105" : {
+      "value" : "2010105",
+      "label" : "Östersjön och dess huvuddelområden",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010110" : {
+      "value" : "2010110",
+      "label" : "Del av havsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010205" : {
+      "value" : "2010205",
+      "label" : "Grupp av sjöar eller tjärnar",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010210" : {
+      "value" : "2010210",
+      "label" : "Sjö eller tjärn",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010215" : {
+      "value" : "2010215",
+      "label" : "Del av sjö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010220" : {
+      "value" : "2010220",
+      "label" : "Konstgjord sjö eller damm",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010225" : {
+      "value" : "2010225",
+      "label" : "Del av konstgjord sjö",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2010230" : {
+      "value" : "2010230",
+      "label" : "Kanal",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020105" : {
+      "value" : "2020105",
+      "label" : "Strömvatten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020110" : {
+      "value" : "2020110",
+      "label" : "Del av strömvatten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2020115" : {
+      "value" : "2020115",
+      "label" : "Fors",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030105" : {
+      "value" : "2030105",
+      "label" : "Källa",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2030110" : {
+      "value" : "2030110",
+      "label" : "Vattengrop",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "2999999" : {
+      "value" : "2999999",
+      "label" : "Annan vattenplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010105" : {
+      "value" : "3010105",
+      "label" : "Stadsområde eller tätort",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3010110" : {
+      "value" : "3010110",
+      "label" : "By eller trakt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020105" : {
+      "value" : "3020105",
+      "label" : "Del av stadsområde eller tätort",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020110" : {
+      "value" : "3020110",
+      "label" : "Park",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3020115" : {
+      "value" : "3020115",
+      "label" : "Torg eller öppen plats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3030105" : {
+      "value" : "3030105",
+      "label" : "Hus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "3999999" : {
+      "value" : "3999999",
+      "label" : "Annat bosättningsobjekt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010105" : {
+      "value" : "4010105",
+      "label" : "Staten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010110" : {
+      "value" : "4010110",
+      "label" : "Regionalförvaltningsverkets verksamhetsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010115" : {
+      "value" : "4010115",
+      "label" : "NTM-centralens verksamhetsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010120" : {
+      "value" : "4010120",
+      "label" : "Landskap",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010125" : {
+      "value" : "4010125",
+      "label" : "Kommun",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4010205" : {
+      "value" : "4010205",
+      "label" : "Råröse",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020105" : {
+      "value" : "4020105",
+      "label" : "Regionförvaltningsverkets huvudsakliga verksamhetsställe",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020110" : {
+      "value" : "4020110",
+      "label" : "NTM-centralens huvudsakliga verksamhetsställe",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020115" : {
+      "value" : "4020115",
+      "label" : "Landskapsförbundets kontor",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020120" : {
+      "value" : "4020120",
+      "label" : "Kommunkansli",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4020199" : {
+      "value" : "4020199",
+      "label" : "Annan administrativ byggnad eller verksamhetsställe",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030105" : {
+      "value" : "4030105",
+      "label" : "Kyrka",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030110" : {
+      "value" : "4030110",
+      "label" : "Annan helig byggnad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4030199" : {
+      "value" : "4030199",
+      "label" : "Annan religiös byggnad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040105" : {
+      "value" : "4040105",
+      "label" : "Begravningsplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4040199" : {
+      "value" : "4040199",
+      "label" : "Annan enhet inom begravningsverksamhet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050105" : {
+      "value" : "4050105",
+      "label" : "Sjukhus",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050199" : {
+      "value" : "4050199",
+      "label" : "Annan enhet inom hälsovård",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4050299" : {
+      "value" : "4050299",
+      "label" : "Enhet inom socialvård",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4059999" : {
+      "value" : "4059999",
+      "label" : "Annan enhet inom social- eller hälsovård",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060105" : {
+      "value" : "4060105",
+      "label" : "Räddnings- eller brandstation",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060110" : {
+      "value" : "4060110",
+      "label" : "Enhet för frivillig brandkår eller avtalsbrandkår",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060199" : {
+      "value" : "4060199",
+      "label" : "Annan enhet inom räddningsväsendet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060205" : {
+      "value" : "4060205",
+      "label" : "Polisstation",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060299" : {
+      "value" : "4060299",
+      "label" : "Annan enhet inom polisväsendet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060305" : {
+      "value" : "4060305",
+      "label" : "Fängelse",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060399" : {
+      "value" : "4060399",
+      "label" : "Annan enhet inom brottspåföljdsväsendet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060405" : {
+      "value" : "4060405",
+      "label" : "Tullstation",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060499" : {
+      "value" : "4060499",
+      "label" : "Annan enhet inom Tullen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060505" : {
+      "value" : "4060505",
+      "label" : "Militärområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060599" : {
+      "value" : "4060599",
+      "label" : "Annan enhet inom Försvarsmakten",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060605" : {
+      "value" : "4060605",
+      "label" : "Gränsövergångsställe",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4060699" : {
+      "value" : "4060699",
+      "label" : "Annan enhet inom Gränsbevakningsväsendet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4069999" : {
+      "value" : "4069999",
+      "label" : "Annan enhet inom säkerhets- eller försvarsbranschen",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070105" : {
+      "value" : "4070105",
+      "label" : "Universitet eller högskola",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070199" : {
+      "value" : "4070199",
+      "label" : "Annan utbildningsenhet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070205" : {
+      "value" : "4070205",
+      "label" : "Forskningsinstitut",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4070299" : {
+      "value" : "4070299",
+      "label" : "Annan forskningsenhet",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080105" : {
+      "value" : "4080105",
+      "label" : "Avfallsbehandlingsanläggning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4080199" : {
+      "value" : "4080199",
+      "label" : "Annan enhet inom avfallshantering",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "4999999" : {
+      "value" : "4999999",
+      "label" : "Annan enhet inom förvaltning eller offentlig tjänst",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010105" : {
+      "value" : "5010105",
+      "label" : "Nationalpark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010110" : {
+      "value" : "5010110",
+      "label" : "Naturpark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5010115" : {
+      "value" : "5010115",
+      "label" : "Annat naturskyddsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999905" : {
+      "value" : "5999905",
+      "label" : "Ödemarksområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999910" : {
+      "value" : "5999910",
+      "label" : "Statens strövområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999915" : {
+      "value" : "5999915",
+      "label" : "Världsarvsobjekt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999920" : {
+      "value" : "5999920",
+      "label" : "Naturminnesmärke",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999925" : {
+      "value" : "5999925",
+      "label" : "Fornlämning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "5999999" : {
+      "value" : "5999999",
+      "label" : "Annat skyddat objekt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010105" : {
+      "value" : "6010105",
+      "label" : "Busstation",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010110" : {
+      "value" : "6010110",
+      "label" : "Färja eller kabelfärja",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010199" : {
+      "value" : "6010199",
+      "label" : "Annan vägtrafikplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010205" : {
+      "value" : "6010205",
+      "label" : "Järnvägsstation eller hållplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010210" : {
+      "value" : "6010210",
+      "label" : "Metrostation",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010299" : {
+      "value" : "6010299",
+      "label" : "Annan trafikplats för spårbunden trafik",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010305" : {
+      "value" : "6010305",
+      "label" : "Hamn",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010310" : {
+      "value" : "6010310",
+      "label" : "Fyr eller säkerhetsanordning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010399" : {
+      "value" : "6010399",
+      "label" : "Annan sjötrafikplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010405" : {
+      "value" : "6010405",
+      "label" : "Flygplats eller flygfält",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010499" : {
+      "value" : "6010499",
+      "label" : "Annan lufttrafikplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010505" : {
+      "value" : "6010505",
+      "label" : "Datacentral",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6010599" : {
+      "value" : "6010599",
+      "label" : "Annan telekommunikationsplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019905" : {
+      "value" : "6019905",
+      "label" : "Bro",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019910" : {
+      "value" : "6019910",
+      "label" : "Tunnel",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019915" : {
+      "value" : "6019915",
+      "label" : "Trafikterminal",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "6019999" : {
+      "value" : "6019999",
+      "label" : "Annan trafikplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010199" : {
+      "value" : "7010199",
+      "label" : "Enhet inom jordbruk",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010299" : {
+      "value" : "7010299",
+      "label" : "Enhet inom vilt- eller fiskerihushållning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010305" : {
+      "value" : "7010305",
+      "label" : "Gruva eller stenbrott",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010310" : {
+      "value" : "7010310",
+      "label" : "Grus- eller sandtäktsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010315" : {
+      "value" : "7010315",
+      "label" : "Torvutvinningsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010399" : {
+      "value" : "7010399",
+      "label" : "Annat marktäktsområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010405" : {
+      "value" : "7010405",
+      "label" : "Industriområde",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010410" : {
+      "value" : "7010410",
+      "label" : "Fabrik",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010415" : {
+      "value" : "7010415",
+      "label" : "Varv",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010499" : {
+      "value" : "7010499",
+      "label" : "Annan enhet inom industri",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010505" : {
+      "value" : "7010505",
+      "label" : "El- eller värmeproduktionsanläggning",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7010599" : {
+      "value" : "7010599",
+      "label" : "Annan enhet inom energiproduktion",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7019999" : {
+      "value" : "7019999",
+      "label" : "Annan enhet inom produktion eller industri",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020105" : {
+      "value" : "7020105",
+      "label" : "Affärscentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7020199" : {
+      "value" : "7020199",
+      "label" : "Annan handelskoncentration",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "7029999" : {
+      "value" : "7029999",
+      "label" : "Annan enhet inom handel",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010105" : {
+      "value" : "8010105",
+      "label" : "Kultur- eller mässcentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010110" : {
+      "value" : "8010110",
+      "label" : "Museum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010115" : {
+      "value" : "8010115",
+      "label" : "Teater",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010120" : {
+      "value" : "8010120",
+      "label" : "Minnesmärke",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8010199" : {
+      "value" : "8010199",
+      "label" : "Annan kulturtjänst",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020105" : {
+      "value" : "8020105",
+      "label" : "Idrottspark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020110" : {
+      "value" : "8020110",
+      "label" : "Idrottsplan",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020115" : {
+      "value" : "8020115",
+      "label" : "Idrottshall",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020120" : {
+      "value" : "8020120",
+      "label" : "Simhall eller friluftsbad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020125" : {
+      "value" : "8020125",
+      "label" : "Golfbana",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020130" : {
+      "value" : "8020130",
+      "label" : "Skid- eller slalomcentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020135" : {
+      "value" : "8020135",
+      "label" : "Skjutbana",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020140" : {
+      "value" : "8020140",
+      "label" : "Motorbana",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020145" : {
+      "value" : "8020145",
+      "label" : "Travbana",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8020199" : {
+      "value" : "8020199",
+      "label" : "Annan idrotts- eller motionsplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030105" : {
+      "value" : "8030105",
+      "label" : "Nöjesfält",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030110" : {
+      "value" : "8030110",
+      "label" : "Djurpark",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030115" : {
+      "value" : "8030115",
+      "label" : "Simstrand",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030120" : {
+      "value" : "8030120",
+      "label" : "Naturcentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030125" : {
+      "value" : "8030125",
+      "label" : "Lägercentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030130" : {
+      "value" : "8030130",
+      "label" : "Turist-, frilufts- eller semestercentrum",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030135" : {
+      "value" : "8030135",
+      "label" : "Campingplats",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030140" : {
+      "value" : "8030140",
+      "label" : "Koloniträdgård",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030145" : {
+      "value" : "8030145",
+      "label" : "Strövled",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030150" : {
+      "value" : "8030150",
+      "label" : "Öde-, rast-, reserverings- eller hyresstuga",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "8030199" : {
+      "value" : "8030199",
+      "label" : "Annan rekreations- eller fritidstjänst",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999905" : {
+      "value" : "9999905",
+      "label" : "Betydande byggnad",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    },
+    "9999999" : {
+      "value" : "9999999",
+      "label" : "Annat kulturobjekt",
+      "status" : "valid",
+      "lang" : "swe",
+      "codelist" : "placetype",
+      "codelistgroup" : "geographic-names"
+    }
+  },
+  "type" : "CodeListDictionary"
+}


### PR DESCRIPTION
Constructed new Ogc Api Search Channel to replace old one.

One needs to set property search.channel.OGC_API_SEARCH_CHANNEL.apikey to ones apikey from NLS.

By default this uses local jsons for placetype and municipality.