### PR TITLE
Handle underscore as space for searching with URL-parameter "address"

### DIFF
--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
@@ -77,7 +77,7 @@ public class AddressParamHandler extends ParamHandler {
 
         final SearchCriteria sc = new SearchCriteria();
         sc.addChannel(channelID);
-        sc.setSearchString(searchString.replaceAll(", ", " ").replaceAll("_", " "));
+        sc.setSearchString(searchString.replaceAll("_", " "));
         sc.setLocale(locale.getLanguage());
         sc.setSRS(srs);
 

--- a/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/control/view/modifier/param/AddressParamHandler.java
@@ -77,7 +77,7 @@ public class AddressParamHandler extends ParamHandler {
 
         final SearchCriteria sc = new SearchCriteria();
         sc.addChannel(channelID);
-        sc.setSearchString(searchString);
+        sc.setSearchString(searchString.replaceAll(", ", " ").replaceAll("_", " "));
         sc.setLocale(locale.getLanguage());
         sc.setSRS(srs);
 


### PR DESCRIPTION
So it works with geocoding like it worked with old search channels: https://github.com/nlsfi/oskari-server-extras/blob/3.6/service-search-nls/src/main/java/fi/nls/oskari/search/util/QueryParser.java#L91