### PR TITLE
Add terrain-profile to oskari-server-extras

### DIFF
--- a/service-terrain-profile/README.md
+++ b/service-terrain-profile/README.md
@@ -1,0 +1,32 @@
+### Terrain Profile
+
+Terrain Profile Backend Service. You send a 2D GeoJSON LineString in EPSG:3067, I respond with a 3D MultiPoint. Each Point resides on your LineString and has the altitude as the third dimension value.
+
+The logic:
+
+1. Client ==> GeoJSON Feature/LineString ==> ActionHandler
+2. ActionHandler ==> WCS Request ==> WCS Service
+3. WCS Service ==> DEM / GeoTIFF ==> ActionHandler
+4. ActionHandler ==> GeoJSON Feature/MultiPoint ==> Client
+
+Requires following properties:
+
+property | description
+-------- | -----------
+`terrain.profile.wcs.endPoint` | URL of the WCS service, query string is NOT ALLOWED (e.g. do NOT specify '?', otherwise it won't work)
+`terrain.profile.wcs.demCoverageId`| id of the DEM coverage in the WCS service
+
+Available parameters per request feature.properties.$key:
+
+property | description
+-------- | -----------
+`numPoints` | Number of points you want back (default 100). If your LineString has more coordinates than this value, we will use that number. Maximum number of points is 1000 (even if your LineString has more coordinates than that).
+`resolution` | *Ignored at the moment*. Used for describing the level-of-detail you're interested in.
+
+Response properties in feature.properties.$key:
+
+property | description
+-------- | -----------
+`numPoints` | Number of points.
+`distanceFromStart` | Array of numbers, each describing the distance from the begin of the LineString. Numbers are ordered and evenly spaced, unless requested numPoints was less than number of coordinates in the requested LineString (see previous table)
+`resolution` | *Ignored at the moment*.

--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
-        <oskari.version>[2.4.0,)</oskari.version>
+        <oskari.version>[2.7.0,)</oskari.version>
         <hystrix.version>1.5.18</hystrix.version>
         <geotools.version>25.1</geotools.version>
         <junit.version>4.13</junit.version>

--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>fi.nls.oskari.extras</groupId>
+    <artifactId>service-terrain-profile</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>Terrain Profile</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jdk.version>1.8</jdk.version>
+        <oskari.version>[2.4.0,)</oskari.version>
+        <hystrix.version>1.5.18</hystrix.version>
+        <geotools.version>25.1</geotools.version>
+        <junit.version>4.13</junit.version>
+        <geojson-jackson.version>1.14</geojson-jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-control</artifactId>
+            <version>${oskari.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-wcs</artifactId>
+            <version>${oskari.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>${hystrix.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>shared-test-resources</artifactId>
+            <version>${oskari.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.grundid.opendatalab</groupId>
+            <artifactId>geojson-jackson</artifactId>
+            <version>${geojson-jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <!-- explicitly define maven-deploy-plugin after other to
+                    force exec order -->
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <executions>
+                    <execution>
+                        <id>deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>oskari_org</id>
+            <name>Oskari.org repository</name>
+            <url>https://oskari.org/repository/maven/releases/</url>
+        </repository>
+        <repository>
+            <id>oskari_org_snapshot</id>
+            <name>Oskari.org snapshot repository</name>
+            <url>https://oskari.org/repository/maven/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>oskari_org</id>
+            <name>Oskari.org repository</name>
+            <url>https://oskari.org/repository/maven/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>oskari_org_snapshot</id>
+            <name>Oskari.org snapshot repository</name>
+            <url>https://oskari.org/repository/maven/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+</project>

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/CommandGetCoverage.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/CommandGetCoverage.java
@@ -1,0 +1,72 @@
+package fi.nls.oskari.terrainprofile;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeoutException;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.PropertyUtil;
+
+/**
+ * HystrixCommand that sends a GetCoverage request to the WCS service via HTTP
+ * and reads the response to a byte array.
+ *
+ * In case the service responds with a 504 status code this
+ * code sleeps for a bit and then tries again up to MAX_RETRIES times
+ */
+public class CommandGetCoverage extends HystrixCommand<byte[]> {
+
+    private static final String GROUP_KEY = "oskari.terrainprofile";
+    private static final String COMMAND_NAME = "getCoverage";
+    private static final int MAX_RETRIES = 5;
+    private static final int SLEEP_BETWEEN_RETRY_MS = 100;
+
+    private final String request;
+
+    public CommandGetCoverage(String request) {
+        super(Setter
+                .withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY))
+                .andCommandKey(HystrixCommandKey.Factory.asKey(COMMAND_NAME))
+                .andThreadPoolPropertiesDefaults(
+                        HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.size", 4))
+                        .withMaxQueueSize(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.limit", 100))
+                        .withQueueSizeRejectionThreshold(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.queue", 100)))
+                .andCommandPropertiesDefaults(
+                        HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(PropertyUtil.getOptional(GROUP_KEY + ".job.timeoutms", 15000))
+                        .withCircuitBreakerRequestVolumeThreshold(PropertyUtil.getOptional(GROUP_KEY + ".failrequests", 10))
+                        .withCircuitBreakerSleepWindowInMilliseconds(PropertyUtil.getOptional(GROUP_KEY + ".sleepwindow", 10000)))
+                );
+        this.request = request;
+    }
+
+    @Override
+    protected byte[] run() throws TimeoutException, IOException, Exception {
+        HttpURLConnection conn = IOHelper.getConnection(request);
+        int sc = conn.getResponseCode();
+
+        int tryCounter = 0;
+        while (sc == HttpURLConnection.HTTP_GATEWAY_TIMEOUT) {
+            if (++tryCounter == MAX_RETRIES) {
+                throw new TimeoutException();
+            }
+            Thread.sleep(SLEEP_BETWEEN_RETRY_MS);
+            conn = IOHelper.getConnection(request);
+            sc = conn.getResponseCode();
+        }
+
+        if (sc == HttpURLConnection.HTTP_OK) {
+            return IOHelper.readBytes(conn);
+        }
+
+        throw new Exception("Unexpected response to GetCoverage");
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/DataPoint.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/DataPoint.java
@@ -1,0 +1,78 @@
+package fi.nls.oskari.terrainprofile;
+
+public class DataPoint {
+
+    private double e;
+    private double n;
+    private double altitude;
+    private double distFromStart;
+    private int gridX;
+    private int gridY;
+    private int tileX;
+    private int tileY;
+
+    public double getE() {
+        return e;
+    }
+
+    public void setE(double e) {
+        this.e = e;
+    }
+
+    public double getN() {
+        return n;
+    }
+
+    public void setN(double n) {
+        this.n = n;
+    }
+
+    public double getAltitude() {
+        return altitude;
+    }
+
+    public void setAltitude(double altitude) {
+        this.altitude = altitude;
+    }
+
+    public double getDistFromStart() {
+        return distFromStart;
+    }
+
+    public void setDistFromStart(double distFromStart) {
+        this.distFromStart = distFromStart;
+    }
+
+    public int getGridX() {
+        return gridX;
+    }
+
+    public void setGridX(int gridX) {
+        this.gridX = gridX;
+    }
+
+    public int getGridY() {
+        return gridY;
+    }
+
+    public void setGridY(int gridY) {
+        this.gridY = gridY;
+    }
+
+    public int getTileX() {
+        return tileX;
+    }
+
+    public void setTileX(int tileX) {
+        this.tileX = tileX;
+    }
+
+    public int getTileY() {
+        return tileY;
+    }
+
+    public void setTileY(int tileY) {
+        this.tileY = tileY;
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/GeomUtil.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/GeomUtil.java
@@ -1,0 +1,57 @@
+package fi.nls.oskari.terrainprofile;
+
+public class GeomUtil {
+
+    public static double[] getEnvelope(double[] coordinates) {
+        double x1 = Double.MAX_VALUE;
+        double y1 = Double.MAX_VALUE;
+        double x2 = Double.MIN_VALUE;
+        double y2 = Double.MIN_VALUE;
+        for (int i = 0; i < coordinates.length;) {
+            double x = coordinates[i++];
+            double y = coordinates[i++];
+            if (x < x1) {
+                x1 = x;
+            }
+            if (x > x2) {
+                x2 = x;
+            }
+            if (y < y1) {
+                y1 = y;
+            }
+            if (y > y2)  {
+                y2 = y;
+            }
+        }
+        return new double[] { x1, y1, x2, y2 };
+    }
+
+    /**
+     * 2D Euclidean distance
+     */
+    public static double getDistance(double x1, double y1, double x2, double y2) {
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * @param lineString [x1,y1,x2,y2,...,xN,yN]
+     * @return the length fo the LineString meaning the sum of Euclidean distance
+     *         between adjacent coordinates
+     */
+    public static double getLength(double[] lineString) {
+        double x1 = lineString[0];
+        double y1 = lineString[1];
+        double sum = 0.0;
+        for (int i = 2; i < lineString.length;) {
+            double x2 = lineString[i++];
+            double y2 = lineString[i++];
+            sum += getDistance(x1, y1, x2, y2);
+            x1 = x2;
+            y1 = y2;
+        }
+        return sum;
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/GridTile.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/GridTile.java
@@ -1,0 +1,42 @@
+package fi.nls.oskari.terrainprofile;
+
+public class GridTile {
+
+    private final int tileX;
+    private final int tileY;
+
+    public GridTile(int tileX, int tileY) {
+        this.tileX = tileX;
+        this.tileY = tileY;
+    }
+
+    public int getTileX() {
+        return tileX;
+    }
+
+    public int getTileY() {
+        return tileY;
+    }
+
+    public int hashCode() {
+        return tileX * 31 + tileY;
+    }
+
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof GridTile)) {
+            return false;
+        }
+        GridTile t = (GridTile) o;
+        if (tileX != t.tileX) {
+            return false;
+        }
+        if (tileY != t.tileY) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
@@ -1,0 +1,315 @@
+package fi.nls.oskari.terrainprofile;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.*;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.service.ServiceRuntimeException;
+import fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor;
+import fi.nls.oskari.terrainprofile.dem.ScaledGrayscaleValueExtractor;
+import fi.nls.oskari.terrainprofile.dem.TileValueExtractor;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.util.ResponseHelper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.geotools.referencing.CRS;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.opengis.referencing.operation.TransformException;
+
+@OskariActionRoute("TerrainProfile")
+public class TerrainProfileHandler extends ActionHandler {
+
+    private static final Logger LOG = LogFactory.getLogger(TerrainProfileHandler.class);
+
+    protected static final String PARAM_ROUTE = "route";
+
+    protected static final String PROPERTY_ENDPOINT = "terrain.profile.wcs.endPoint";
+    protected static final String PROPERTY_ENDPOINT_SRS = "terrain.profile.wcs.srs";
+    protected static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
+    protected static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
+    protected static final String PROPERTY_DEM_TYPE = "terrain.profile.wcs.demType";
+    protected static final String PROPERTY_DEM_SCALE = "terrain.profile.wcs.demScale";
+    protected static final String PROPERTY_DEM_OFFSET = "terrain.profile.wcs.demOffset";
+
+    protected static final String JSON_PROPERTY_PROPERTIES = "properties";
+    protected static final String JSON_PROPERTY_NUM_POINTS = "numPoints";
+    protected static final String JSON_PROPERTY_SCALE_FACTOR = "scaleFactor";
+    protected static final String JSON_PROPERTY_DISTANCE_FROM_START = "distanceFromStart";
+
+    private static final int NUM_POINTS_MAX = 1000;
+    private static final String DEFAULT_SRS = "EPSG:3067";
+
+    private final ObjectMapper om;
+    private TerrainProfileService tps;
+    private String serviceSrs;
+
+    public TerrainProfileHandler() {
+        this(new ObjectMapper(), null);
+    }
+
+    public TerrainProfileHandler(ObjectMapper om, TerrainProfileService tps) {
+        this.om = om;
+        this.tps = tps;
+    }
+
+    @Override
+    public void init() {
+        try {
+            tps = getService();
+        } catch (NoSuchElementException propertyMissing) {
+            // fatal, throw an exception so this route is not added to available actions
+            throw new ServiceRuntimeException(
+                    "Failed to init TerrainProfileService: " + propertyMissing.getMessage());
+        } catch (ServiceException ex) {
+            // not fatal, proceed with init and try again later
+            LOG.error("Failed to init TerrainProfileService: " + ex.getMessage(), ex);
+        }
+        serviceSrs = PropertyUtil.get(PROPERTY_ENDPOINT_SRS, DEFAULT_SRS).toUpperCase();
+    }
+
+    protected synchronized TerrainProfileService getService() throws ServiceException {
+        if (tps == null) {
+            tps = new TerrainProfileService(
+                    PropertyUtil.getNecessary(PROPERTY_ENDPOINT),
+                    PropertyUtil.getNecessary(PROPERTY_DEM_COVERAGE_ID),
+                    getTileValueExtractor());
+        }
+        return tps;
+    }
+
+    private Supplier<TileValueExtractor> getTileValueExtractor() {
+        String type = PropertyUtil.get(PROPERTY_DEM_TYPE, FloatAsIsValueExtractor.ID);
+
+        switch (type) {
+        case ScaledGrayscaleValueExtractor.ID:
+            double scale = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_SCALE));
+            double offset = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_OFFSET));
+            short noDataS = getNoDataValue(Short::parseShort).shortValue();
+            return () -> new ScaledGrayscaleValueExtractor(offset, scale, noDataS);
+
+        case FloatAsIsValueExtractor.ID:
+        default:
+            float noDataF = getNoDataValue(Float::parseFloat).floatValue();
+            return () -> new FloatAsIsValueExtractor(noDataF);
+        }
+    }
+
+    private Number getNoDataValue(Function<String, Number> parser) {
+        String noDataStr = PropertyUtil.getOptional(PROPERTY_NODATA_VALUE);
+        if (noDataStr != null && !noDataStr.isEmpty()) {
+            try {
+                Number noDataValue = parser.apply(noDataStr);
+                LOG.debug("NODATA value:", noDataValue);
+                return noDataValue;
+            } catch (NumberFormatException e) {
+                LOG.warn("Could not parse NODATA value from " + noDataStr);
+            }
+        }
+        return Double.NaN;
+    }
+
+    @Override
+    public void handleAction(ActionParameters params) throws ActionException {
+        JsonNode route = getParamRoute(params);
+
+        double[] points = getRoutePoints(route);
+        int numPoints = getNumPoints(route.get(JSON_PROPERTY_PROPERTIES));
+        double scaleFactor = getScaleFactor(route.get(JSON_PROPERTY_PROPERTIES));
+
+        // Allow route to be GC'd
+        route = null;
+
+        MathTransform transform = getTransform(serviceSrs, params);
+
+        if (transform != null) {
+            transformInPlace(points, transform);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Number of coords:", points.length / 2,
+                    "line:", Arrays.toString(points), "numPoints", numPoints);
+        }
+
+        try {
+            List<DataPoint> dp = getService().getTerrainProfile(points, numPoints, scaleFactor);
+            if (transform != null) {
+                transformInPlace(dp, transform);
+            }
+            writeResponse(params, dp);
+        } catch (ServiceException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+    }
+
+    private JsonNode getParamRoute(ActionParameters params) throws ActionParamsException {
+        try {
+            String routeJson = params.getRequiredParam(PARAM_ROUTE);
+            return om.readTree(routeJson);
+        } catch (JsonProcessingException e) {
+            throw new ActionParamsException("Expected JSON object for param " + PARAM_ROUTE, e);
+        }
+    }
+
+    protected double[] getRoutePoints(JsonNode route) throws ActionParamsException {
+        JsonNode geometry = route.get("geometry");
+        if (geometry == null || !geometry.isObject()) {
+            throw new ActionParamsException("Invalid input - expected GeoJSON feature");
+        }
+
+        JsonNode type = geometry.get("type");
+        if (type == null || !type.isTextual() || !"LineString".equals(type.textValue())) {
+            throw new ActionParamsException("Invalid input - expected LineString geometry");
+        }
+
+        JsonNode coordinates = geometry.get("coordinates");
+        if (coordinates == null || !coordinates.isArray()) {
+            throw new ActionParamsException("Invalid input - expected LineString geometry");
+        }
+        int len = coordinates.size();
+        if (len < 2) {
+            throw new ActionParamsException("Invalid input - expected LineString with atleast two coordinates");
+        } else if (len > NUM_POINTS_MAX) {
+            throw new ActionParamsException("Invalid input - too many coordinates, maximum is " + NUM_POINTS_MAX);
+        }
+
+        double[] xy = new double[len * 2];
+        for (int i = 0; i < len; i++) {
+            JsonNode coordinate = coordinates.get(i);
+            if (coordinate == null || !coordinate.isArray()) {
+                throw new ActionParamsException("Invalid input - expected LineString geometry");
+            }
+            JsonNode x = coordinate.get(0);
+            JsonNode y = coordinate.get(1);
+            if (!x.isNumber() || !y.isNumber()) {
+                throw new ActionParamsException("Invalid input - expected LineString geometry");
+            }
+            xy[i * 2 + 0] = x.asDouble();
+            xy[i * 2 + 1] = y.asDouble();
+        }
+        return xy;
+    }
+
+    protected int getNumPoints(JsonNode props) throws ActionParamsException {
+        if (props == null || !props.has(JSON_PROPERTY_NUM_POINTS)) {
+            return 0;
+        }
+        JsonNode numPoints = props.get(JSON_PROPERTY_NUM_POINTS);
+        if (!numPoints.isIntegralNumber()) {
+            throw new ActionParamsException(String.format(
+                    "Invalid property value '%s'", JSON_PROPERTY_NUM_POINTS));
+        }
+        return Math.min(numPoints.asInt(), NUM_POINTS_MAX);
+    }
+
+    protected double getScaleFactor(JsonNode props) {
+        double fallback = 0.0;
+        if (props == null || !props.has(JSON_PROPERTY_SCALE_FACTOR)) {
+            return fallback;
+        }
+        return props.get(JSON_PROPERTY_SCALE_FACTOR).asDouble(fallback);
+    }
+
+    private MathTransform getTransform(String serviceCrs, ActionParameters params) throws ActionParamsException {
+        try {
+            String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, DEFAULT_SRS);
+            if (targetSRS.equals(serviceSrs)) {
+                return null;
+            }
+            CoordinateReferenceSystem fromCRS = CRS.decode(serviceCrs);
+            CoordinateReferenceSystem toCRS = CRS.decode(targetSRS);
+            boolean lenient = true; // allow for some error due to different datums
+            return CRS.findMathTransform(fromCRS, toCRS, lenient);
+        } catch (FactoryException e) {
+            throw new ActionParamsException("Invalid " + ActionConstants.PARAM_SRS);
+        }
+    }
+
+    private void transformInPlace(double[] xy, MathTransform transform) throws ActionException {
+        try {
+            transform.transform(xy, 0, xy, 0, xy.length / 2);
+        } catch (TransformException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+    }
+
+    private void transformInPlace(List<DataPoint> dp, MathTransform transform) throws ActionException {
+        try {
+            double[] xy = new double[2];
+            for (DataPoint cur : dp) {
+                xy[0] = cur.getE();
+                xy[1] = cur.getN();
+                transform.transform(xy, 0, xy, 0, 1);
+                cur.setE(xy[0]);
+                cur.setN(xy[1]);
+            }
+        } catch (TransformException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+    }
+
+    protected void writeResponse(ActionParameters params, List<DataPoint> dp) throws ActionException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator json = om.getFactory().createGenerator(baos)) {
+            writeMultiPointFeature(dp, json);
+        } catch (IOException e) {
+            throw new ActionException("Failed to encode GeoJSON", e);
+        }
+        ResponseHelper.writeResponse(params, 200, IOHelper.CONTENT_TYPE_JSON, baos);
+    }
+
+    protected static void writeMultiPointFeature(List<DataPoint> dp,
+            JsonGenerator json) throws IOException {
+        json.writeStartObject();
+        json.writeStringField("type", "Feature");
+
+        json.writeFieldName("geometry");
+        json.writeStartObject();
+        json.writeStringField("type", "MultiPoint");
+        json.writeFieldName("coordinates");
+        json.writeStartArray();
+        for (DataPoint p : dp) {
+            json.writeStartArray();
+            json.writeNumber(p.getE());
+            json.writeNumber(p.getN());
+            double alt = p.getAltitude();
+            if (Double.isNaN(alt)) {
+                json.writeNull();
+            } else {
+                json.writeNumber(alt);
+            }
+            json.writeEndArray();
+        }
+        json.writeEndArray();
+        json.writeEndObject();
+
+        json.writeFieldName("properties");
+        json.writeStartObject();
+        json.writeNumberField(JSON_PROPERTY_NUM_POINTS, dp.size());
+        json.writeFieldName(JSON_PROPERTY_DISTANCE_FROM_START);
+        json.writeStartArray();
+        for (DataPoint p : dp) {
+            json.writeNumber(p.getDistFromStart());
+        }
+        json.writeEndArray();
+        json.writeEndObject();
+
+        json.writeEndObject();
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
@@ -1,0 +1,339 @@
+package fi.nls.oskari.terrainprofile;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor;
+import fi.nls.oskari.terrainprofile.dem.TileValueExtractor;
+import fi.nls.oskari.terrainprofile.dem.TiledTiffDEM;
+import org.oskari.wcs.capabilities.Capabilities;
+import org.oskari.wcs.coverage.CoverageDescription;
+import org.oskari.wcs.coverage.RectifiedGridCoverage;
+import org.oskari.wcs.extension.scaling.ScaleByFactor;
+import org.oskari.wcs.geotiff.TIFFReader;
+import org.oskari.wcs.gml.RectifiedGrid;
+import org.oskari.wcs.parser.CapabilitiesParser;
+import org.oskari.wcs.parser.CoverageDescriptionsParser;
+import org.oskari.wcs.request.DescribeCoverage;
+import org.oskari.wcs.request.GetCapabilities;
+import org.oskari.wcs.request.GetCoverage;
+import org.xml.sax.SAXException;
+
+import com.netflix.hystrix.exception.HystrixRuntimeException;
+
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.oskari.util.IOHelper;
+
+public class TerrainProfileService {
+
+    private static final String FORMAT_TIFF = "image/tiff";
+    private static final int REQUEST_MAX_SIZE_METRES = 8192;
+    private static final int REQUEST_SIZE_DEFAULT = 1024;
+    private static final int SCALE_SIZE_THRESHOLD = 2048;
+    private static final double[] SCALE_FACTORS = {
+            1,
+            0.5,
+            0.25,
+            0.125,
+            0.0625,
+            0.03125,
+            0.015625,
+            0.0078125
+    };
+
+    private final String endPoint;
+    private final Supplier<TileValueExtractor> extractorGenerator;
+    private final Capabilities caps;
+    private final RectifiedGridCoverage desc;
+    private final double originEast;
+    private final double originNorth;
+    private final double offsetVectorX;
+    private final double offsetVectorY;
+
+    public TerrainProfileService(String endPoint, String coverageId) throws ServiceException {
+        this(endPoint, coverageId, () -> new FloatAsIsValueExtractor(Float.NaN));
+    }
+
+    public TerrainProfileService(String endPoint, String coverageId, Supplier<TileValueExtractor> extractorGenerator) throws ServiceException {
+        try {
+            this.endPoint = endPoint;
+            this.extractorGenerator = extractorGenerator;
+            caps = getCapabilities(endPoint);
+            CoverageDescription tmp = describeCoverage(endPoint, coverageId);
+            if (!(tmp instanceof RectifiedGridCoverage)) {
+                throw new ServiceException("Expected coverage of type RectifiedGridCoverage");
+            }
+            desc = (RectifiedGridCoverage) tmp;
+            RectifiedGrid grid = desc.getDomainSet();
+            originEast = grid.getOrigin().getPos()[0];
+            originNorth = grid.getOrigin().getPos()[1];
+            offsetVectorX = grid.getOffsetVectors()[0].getPos()[0];
+            offsetVectorY = grid.getOffsetVectors()[1].getPos()[1];
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            throw new ServiceException("Failed to initialize", e);
+        }
+    }
+
+    private Capabilities getCapabilities(String endPoint)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, String> params = GetCapabilities.toQueryParameters();
+        String url = IOHelper.constructUrl(endPoint, params);
+        HttpURLConnection conn = IOHelper.getConnection(url);
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            return CapabilitiesParser.parse(in);
+        }
+    }
+
+    private CoverageDescription describeCoverage(String endPoint, String coverageId)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, String> params = DescribeCoverage.toQueryParameters(coverageId);
+        String url = IOHelper.constructUrl(endPoint, params);
+        HttpURLConnection conn = IOHelper.getConnection(url);
+        try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+            return CoverageDescriptionsParser.parse(in).get(0);
+        }
+    }
+
+    /**
+     * @param coordinates
+     *      array of doubles [e1,n1,...,eN,nN]
+     *      e = east (m), n = north (m)
+     * @param numPoints
+     *      number of coordinates you want back (interpolate more points if necessary)
+     * @param scaleFactor
+     *      non-positive considered null, must be 1/2^n, where 0<=n<=8
+     */
+    public List<DataPoint> getTerrainProfile(double[] coordinates, int numPoints, double scaleFactor)
+            throws ServiceException {
+        double[] extent = GeomUtil.getEnvelope(coordinates);
+
+        scaleFactor = determineScaleFactor(scaleFactor, extent);
+
+        double dx = offsetVectorX / scaleFactor;
+        double dy = offsetVectorY / scaleFactor;
+
+        int tileSize = getTileSize(extent, dx);
+
+        if (coordinates.length < numPoints * 2) {
+            coordinates = interpolate(coordinates, numPoints);
+        }
+
+        List<DataPoint> points = createDataPoints(coordinates, tileSize, dx, dy);
+
+        Map<GridTile, List<DataPoint>> pointsByTile = points.stream()
+                .collect(Collectors.groupingBy(p -> new GridTile(p.getTileX(), p.getTileY())));
+        for (List<DataPoint> pointsInTile : pointsByTile.values()) {
+            setAltitudes(pointsInTile, scaleFactor, dx, dy);
+        }
+
+        points.sort(Comparator.comparingDouble(DataPoint::getDistFromStart));
+
+        return points;
+    }
+
+    private int getTileSize(double[] extent, double dx) {
+        int tileSize = REQUEST_SIZE_DEFAULT;
+        while (tileSize * dx > REQUEST_MAX_SIZE_METRES && tileSize > 32) {
+            tileSize /= 2;
+        }
+        if (tileSize < 64) {
+            tileSize = 1;
+        }
+        return tileSize;
+    }
+
+    private double determineScaleFactor(double scaleFactor, double[] extent) {
+        if (scaleFactor > 0) {
+            for (double temp : SCALE_FACTORS) {
+                if (scaleFactor == temp) {
+                    return scaleFactor;
+                }
+            }
+        }
+
+        double widthMetres = extent[2] - extent[0];
+        double heightMetres = extent[3] - extent[1];
+        for (double sf : SCALE_FACTORS) {
+            double xPerPx = Math.abs(offsetVectorX / sf);
+            double yPerPx = Math.abs(offsetVectorY / sf);
+            int widthPx = (int) Math.round(widthMetres / xPerPx);
+            int heightPx = (int) Math.round(heightMetres / yPerPx);
+            if (widthPx <= SCALE_SIZE_THRESHOLD && heightPx <= SCALE_SIZE_THRESHOLD) {
+                return sf;
+            }
+        }
+        return SCALE_FACTORS[SCALE_FACTORS.length - 1];
+    }
+
+    private double[] interpolate(double[] coordinates, int numDataPoints) {
+        double[] interpolated = new double[numDataPoints * 2];
+
+        double segmentLength = GeomUtil.getLength(coordinates) / (numDataPoints - 1);
+        double remainingSegmentLength = segmentLength;
+
+        int i = 0;
+        int j = 0;
+
+        double x0 = coordinates[j++];
+        double y0 = coordinates[j++];
+        double x1 = coordinates[j++];
+        double y1 = coordinates[j++];
+
+        double dx = x1 - x0;
+        double dy = y1 - y0;
+        double distanceToNextPoint = Math.sqrt(dx * dx + dy * dy);
+        double dxNormalized = dx / distanceToNextPoint;
+        double dyNormalized = dy / distanceToNextPoint;
+
+        // Add first point
+        interpolated[i++] = x0;
+        interpolated[i++] = y0;
+
+        while (i < interpolated.length - 2) {
+            if (distanceToNextPoint < remainingSegmentLength) {
+                remainingSegmentLength -= distanceToNextPoint;
+                x0 = x1;
+                y0 = y1;
+                x1 = coordinates[j++];
+                y1 = coordinates[j++];
+                dx = x1 - x0;
+                dy = y1 - y0;
+                distanceToNextPoint = Math.sqrt(dx * dx + dy * dy);
+                dxNormalized = dx / distanceToNextPoint;
+                dyNormalized = dy / distanceToNextPoint;
+            } else {
+                x0 += remainingSegmentLength * dxNormalized;
+                y0 += remainingSegmentLength * dyNormalized;
+                interpolated[i++] = x0;
+                interpolated[i++] = y0;
+                distanceToNextPoint -= remainingSegmentLength;
+                remainingSegmentLength = segmentLength;
+            }
+        }
+
+        // Add last point
+        interpolated[interpolated.length - 2] = coordinates[coordinates.length - 2];
+        interpolated[interpolated.length - 1] = coordinates[coordinates.length - 1];
+
+        return interpolated;
+    }
+
+    private List<DataPoint> createDataPoints(double[] coordinates, int tileSize, double dx, double dy) {
+        double e0 = coordinates[0];
+        double n0 = coordinates[1];
+        double distFromStart = 0.0;
+
+        List<DataPoint> points = new ArrayList<>(coordinates.length / 2);
+        for (int i = 0; i < coordinates.length;) {
+            double e1 = coordinates[i++];
+            double n1 = coordinates[i++];
+            distFromStart += GeomUtil.getDistance(e1, n1, e0, n0);
+
+            int gridX = (int) Math.round(((e1 - originEast) / dx));
+            int gridY = (int) Math.round(((n1 - originNorth) / dy));
+            int tileX = gridX / tileSize;
+            int tileY = gridY / tileSize;
+
+            DataPoint dp = new DataPoint();
+            dp.setE(e1);
+            dp.setN(n1);
+            dp.setDistFromStart(distFromStart);
+            dp.setGridX(gridX);
+            dp.setGridY(gridY);
+            dp.setTileX(tileX);
+            dp.setTileY(tileY);
+            points.add(dp);
+
+            e0 = e1;
+            n0 = n1;
+        }
+        return points;
+    }
+
+    private void setAltitudes(List<DataPoint> pointsInTile, double scaleFactor, double dx, double dy)
+            throws ServiceException {
+        int minGridX = Integer.MAX_VALUE;
+        int minGridY = Integer.MAX_VALUE;
+        int maxGridX = Integer.MIN_VALUE;
+        int maxGridY = Integer.MIN_VALUE;
+
+        for (DataPoint p : pointsInTile)  {
+            int gridX = p.getGridX();
+            if (gridX < minGridX) {
+                minGridX = gridX;
+            }
+            if (gridX > maxGridX) {
+                maxGridX = gridX;
+            }
+            int gridY = p.getGridY();
+            if (gridY < minGridY) {
+                minGridY = gridY;
+            }
+            if (gridY > maxGridY) {
+                maxGridY = gridY;
+            }
+        }
+
+        double eastMin = originEast + minGridX * dx;
+        double eastMax;
+        if (minGridX == maxGridX) {
+            eastMax = eastMin + dx;
+        } else {
+            eastMax = originEast + (maxGridX + 1) * dx;
+        }
+
+        double northMin = originNorth + maxGridY * dy;
+        double northMax;
+        if (minGridY == maxGridY) {
+            northMax = northMin - dy;
+        } else {
+            northMax = originNorth + (minGridY - 1) * dy;
+        }
+
+        GetCoverage getCoverage = new GetCoverage(caps, desc, FORMAT_TIFF);
+        getCoverage.subset("E", eastMin, eastMax);
+        getCoverage.subset("N", northMin, northMax);
+        getCoverage.scaling(new ScaleByFactor(scaleFactor));
+        Map<String, String[]> getCoverageKVP = getCoverage.toKVP();
+
+        String queryString = IOHelper.getParamsMultiValue(getCoverageKVP);
+        String request = endPoint + "?" + queryString;
+        byte[] response;
+        try {
+            response = new CommandGetCoverage(request).execute();
+        } catch (HystrixRuntimeException e) {
+            if (e.getCause() instanceof TimeoutException) {
+                throw new ServiceException("Timeout");
+            }
+            throw new ServiceException("Failed to retrieve data from WCS", e);
+        }
+
+        try {
+            TIFFReader r = new TIFFReader(response);
+            TiledTiffDEM tiff = new TiledTiffDEM(r, extractorGenerator.get());
+            setAltitudes(pointsInTile, tiff, minGridX, minGridY);
+        } catch (IllegalArgumentException e) {
+            throw new ServiceException("Unexpected TIFF file", e);
+        }
+    }
+
+    private void setAltitudes(List<DataPoint> pointsInTile, TiledTiffDEM tiff, int minGridX, int minGridY) {
+        for (DataPoint point : pointsInTile) {
+            int x = point.getGridX() - minGridX;
+            int y = point.getGridY() - minGridY;
+            point.setAltitude(tiff.getValue(x, y));
+        }
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/FloatAsIsValueExtractor.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/FloatAsIsValueExtractor.java
@@ -1,0 +1,35 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+public class FloatAsIsValueExtractor implements TileValueExtractor {
+
+    public static final String ID = "FLOAT";
+
+    private final float noData;
+    private final Map<Integer, float[]> tileCache = new HashMap<>();
+
+    public FloatAsIsValueExtractor(float noData) {
+        this.noData = noData;
+    }
+
+    @Override
+    public void validate(IFD ifd) throws IllegalArgumentException {
+        if (ifd.getSampleFormat()[0] != 3) {
+            throw new IllegalArgumentException("Unexpected sample format, expected float32");
+        }
+    }
+
+    @Override
+    public double getTileValue(TIFFReader r, IFD ifd, int ifdIdx, int tileIndex, int tileOffset) {
+        int n = ifd.getTileWidth() * ifd.getTileHeight();
+        float[] tile = tileCache.computeIfAbsent(tileIndex, __ -> r.readTile(ifdIdx, tileIndex, new float[n]));
+        float value = tile[tileOffset];
+        return (value == noData) ? Double.NaN : value;
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/ScaledGrayscaleValueExtractor.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/ScaledGrayscaleValueExtractor.java
@@ -1,0 +1,49 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+public class ScaledGrayscaleValueExtractor implements TileValueExtractor {
+
+    public static final String ID = "INT";
+
+    private final double scaleInv;
+    private final double negatedOffset;
+    private final int noData;
+
+    private final Map<Integer, short[]> tileCache = new HashMap<>();
+
+    private boolean unsigned;
+
+    public ScaledGrayscaleValueExtractor(double scale, double offset, int noData) {
+        this.scaleInv = 1.0 / scale;
+        this.negatedOffset = -offset;
+        this.noData = noData;
+    }
+
+    @Override
+    public void validate(IFD ifd) throws IllegalArgumentException {
+        if (ifd.getSamplesPerPixel() != 1) {
+            throw new IllegalArgumentException("Unexpected samples per pixel, expected 1 (grayscale)");
+        }
+        if (ifd.getSampleFormat()[0] != 1 && ifd.getSampleFormat()[1] != 2) {
+            throw new IllegalArgumentException("Unexpected sample format, expected unsigned or signed integer");
+        }
+        unsigned = ifd.getSampleFormat()[0] == 1;
+        if (ifd.getBitsPerSample()[0] != 16) {
+            throw new IllegalArgumentException("Unexpected bits per sample, expected 16 bits per sample (grayscale)");
+        }
+    }
+
+    @Override
+    public double getTileValue(TIFFReader r, IFD ifd, int ifdIdx, int tileIndex, int tileOffset) {
+        int n = ifd.getTileWidth() * ifd.getTileHeight();
+        short[] tile = tileCache.computeIfAbsent(tileIndex, __ -> r.readTile(ifdIdx, tileIndex, new short[n]));
+        int value = unsigned ? tile[tileOffset] & 0xFFFF : tile[tileOffset];
+        return value == noData ? Double.NaN : (value + negatedOffset) * scaleInv;
+    }
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/TileValueExtractor.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/TileValueExtractor.java
@@ -1,0 +1,16 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+public interface TileValueExtractor {
+
+    public void validate(IFD ifd) throws IllegalArgumentException;
+
+    /**
+     * @return value at tileIndex, tileOffset or Double.NaN if the value is NO_DATA
+     */
+    public double getTileValue(TIFFReader r, IFD ifd, int ifdIdx, int tileIndex, int tileOffset);
+
+
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/TiledTiffDEM.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/dem/TiledTiffDEM.java
@@ -1,0 +1,60 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+
+public class TiledTiffDEM {
+
+    private static final Logger LOG = LogFactory.getLogger(TiledTiffDEM.class);
+
+    private static final int IFD_IDX = 0;
+
+    private final TIFFReader r;
+    private final IFD ifd;
+    private final int tilesAcross;
+    private final TileValueExtractor extractor;
+
+    public TiledTiffDEM(TIFFReader r, TileValueExtractor extractor) throws IllegalArgumentException {
+        this.r = r;
+        this.ifd = r.getIFD(IFD_IDX);
+        this.extractor = extractor;
+
+        if (ifd.getTileOffsets() == null) {
+            throw new IllegalArgumentException("Unexpected TIFF file, expected Tiled TIFF");
+        }
+        extractor.validate(ifd);
+
+        int tw = ifd.getTileWidth();
+        int th = ifd.getTileHeight();
+
+        int tilesAcross = ifd.getWidth() / tw;
+        if (tilesAcross * tw < ifd.getWidth()) {
+            tilesAcross++;
+        }
+        this.tilesAcross = tilesAcross;
+
+        int tilesDown = ifd.getHeight() / th;
+        if (tilesDown * th < ifd.getHeight()) {
+            tilesDown++;
+        }
+
+        LOG.debug("Width:", ifd.getWidth(), "Height:", ifd.getHeight(),
+                "TileWidth:", tw, "TileHeight:", th,
+                "TilesAcross:", tilesAcross, "TilesDown:", tilesDown,
+                "NumTiles:", ifd.getTileOffsets().length);
+    }
+
+    public double getValue(int x, int y) {
+        int tileX = x / ifd.getTileWidth();
+        int offX = x % ifd.getTileWidth();
+        int tileY = y / ifd.getTileHeight();
+        int offY = y % ifd.getTileHeight();
+        int tileIndex = tileY * tilesAcross + tileX;
+        int tileOffset = offY * ifd.getTileWidth() + offX;
+        return extractor.getTileValue(r, ifd, IFD_IDX, tileIndex, tileOffset);
+    }
+
+}

--- a/service-terrain-profile/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/service-terrain-profile/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,6 @@
+# This Annotation processor will be run automatically by the compiler
+# in order to detect all of the places that the @OskariActionRoute annotation
+# is used.
+
+fi.nls.oskari.annotation.OskariActionRouteAnnotationProcessor
+

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileHandlerTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileHandlerTest.java
@@ -1,0 +1,233 @@
+package fi.nls.oskari.terrainprofile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.service.ServiceException;
+import fi.nls.test.control.MockServletOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.ParserConfigurationException;
+import org.geojson.Feature;
+import org.geojson.LineString;
+import org.geojson.LngLatAlt;
+import org.geojson.MultiPoint;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+public class TerrainProfileHandlerTest {
+
+    private static ObjectMapper om;
+    private static TerrainProfileHandler handler;
+
+    @BeforeClass
+    public static void init() throws IOException, ParserConfigurationException, SAXException {
+        om = new ObjectMapper();
+        handler = new TerrainProfileHandler(om, null);
+    }
+
+    @Test
+    public void whenRouteParameterIsMissingThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(null);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Required parameter 'route' missing!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenRouteParameterIsEmptyThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn("");
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Required parameter 'route' missing!", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenRouteParameterIsNotGeoJSONFeatureThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        LineString line = new LineString();
+        line.add(new LngLatAlt(100, 100));
+        line.add(new LngLatAlt(200, 100));
+        String lineStr = om.writeValueAsString(line);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(lineStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Invalid input - expected GeoJSON feature", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenGeometryOfFeatureIsNotLineStringThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        Feature feature = new Feature();
+        MultiPoint mp = new MultiPoint();
+        mp.add(new LngLatAlt(100, 100));
+        mp.add(new LngLatAlt(200, 100));
+        feature.setGeometry(mp);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Invalid input - expected LineString geometry", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenLineHasOnePointThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        Feature feature = new Feature();
+        LineString ls = new LineString();
+        ls.add(new LngLatAlt(0, 0));
+        feature.setGeometry(ls);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Invalid input - expected LineString with atleast two coordinates", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenLineHasTooManyPointsThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        Feature feature = new Feature();
+        LineString ls = new LineString();
+        for (int i = 0; i < 10000; i++) {
+            ls.add(new LngLatAlt(i, i));
+        }
+        feature.setGeometry(ls);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertTrue(e.getMessage().startsWith("Invalid input"
+                    + " - too many coordinates, maximum is"));
+        }
+    }
+
+    @Test
+    @Ignore("Depends on an outside API")
+    public void whenInputIsCorrectWePass() throws IOException, ActionException, ServiceException {
+        Feature feature = new Feature();
+        LineString line = new LineString();
+        line.add(new LngLatAlt(500000, 6822000));
+        line.add(new LngLatAlt(501000, 6823000));
+        feature.setGeometry(line);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getOutputStream()).thenReturn(new MockServletOutputStream(baos));
+
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+        params.setResponse(response);
+
+        String endPoint = "https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows";
+        String coverageId = "korkeusmalli__korkeusmalli";
+        TerrainProfileService tps = new TerrainProfileService(endPoint, coverageId);
+        new TerrainProfileHandler(om, tps).handleAction(params);
+    }
+
+    @Test
+    public void testWriteMultiPointFeature() throws IOException {
+        DataPoint p1 = new DataPoint();
+        p1.setE(0.0);
+        p1.setN(0.0);
+        p1.setAltitude(300.0f);
+        p1.setDistFromStart(0.0);
+
+        DataPoint p2 = new DataPoint();
+        p2.setE(100.0);
+        p2.setN(0.0);
+        p2.setAltitude(400.0f);
+        p2.setDistFromStart(100.0);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator json = new JsonFactory().createGenerator(baos)) {
+            TerrainProfileHandler.writeMultiPointFeature(Arrays.asList(p1, p2), json);
+        }
+
+        ObjectMapper om = new ObjectMapper();
+        Feature feature = om.readValue(baos.toByteArray(), Feature.class);
+
+        MultiPoint mp = (MultiPoint) feature.getGeometry();
+        List<LngLatAlt> coordinates = mp.getCoordinates();
+        assertEquals(2, coordinates.size());
+
+        LngLatAlt c1 = coordinates.get(0);
+        assertEquals(0.0, c1.getLongitude(), 0.0);
+        assertEquals(0.0, c1.getLatitude(), 0.0);
+        assertEquals(300.0, c1.getAltitude(), 0.0);
+
+        LngLatAlt c2 = coordinates.get(1);
+        assertEquals(100.0, c2.getLongitude(), 0.0);
+        assertEquals(0.0, c2.getLatitude(), 0.0);
+        assertEquals(400.0, c2.getAltitude(), 0.0);
+
+        int numPoints = (Integer) feature.getProperty(TerrainProfileHandler.JSON_PROPERTY_NUM_POINTS);
+        assertEquals(2, numPoints);
+
+        List<Double> distFromStart = feature.getProperty(TerrainProfileHandler.JSON_PROPERTY_DISTANCE_FROM_START);
+        assertEquals(2, distFromStart.size());
+        assertEquals(0.0, distFromStart.get(0).doubleValue(), 0.0);
+        assertEquals(100.0, distFromStart.get(1).doubleValue(), 0.0);
+    }
+
+}

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileServiceTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileServiceTest.java
@@ -1,0 +1,107 @@
+package fi.nls.oskari.terrainprofile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.service.ServiceException;
+
+@Ignore("Depends on an outside API")
+public class TerrainProfileServiceTest {
+
+    private static String endPoint = "https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows";
+    private static String coverageId = "korkeusmalli__korkeusmalli";
+    private static TerrainProfileService tps;
+
+    @BeforeClass
+    public static void setup() throws ServiceException {
+        tps = new TerrainProfileService(endPoint, coverageId);
+    }
+
+    @Test
+    public void offsetIsCorrect() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        double[] coordinates = new double[] {
+                500002, 6822001,
+                501003, 6821004,
+                502006, 6823007,
+                501003, 6822509,
+                500502, 6823206
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 0, -1);
+        for (DataPoint p : points) {
+            double e = p.getE();
+            double n = p.getN();
+            DataPoint single = tps.getTerrainProfile(new double[] { e, n }, 0, -1).get(0);
+            assertEquals(e, single.getE(), 0.0);
+            assertEquals(n, single.getN(), 0.0);
+            assertEquals(p.getAltitude(), single.getAltitude(), 0.0);
+        }
+    }
+
+    @Test
+    @Ignore("Too long")
+    public void testLongLine() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        double[] coordinates = {
+                279816, 6640056,
+                532571, 7762366
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 100, -1);
+        for (DataPoint p : points) {
+            assertNotEquals(0, p.getAltitude(), 0);
+        }
+    }
+
+    @Test
+    public void testHorizontalLine() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        double[] coordinates = {
+                400000, 6700000,
+                404094, 6700000
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 100, -1);
+        for (DataPoint p : points) {
+            assertNotEquals(0, p.getAltitude(), 0);
+        }
+    }
+
+    @Test
+    public void tesVerticalLine() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        double[] coordinates = {
+                400000, 6700000,
+                400000, 6704094
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 100, -1);
+        for (DataPoint p : points) {
+            assertNotEquals(0, p.getAltitude(), 0);
+        }
+    }
+
+    @Test
+    public void testSmallLine() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        double[] coordinates = {
+                400000, 6700000,
+                400256, 6700000,
+                400256, 6700256,
+                400000, 6700256
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 100, -1);
+        for (DataPoint p : points) {
+            assertNotEquals(0, p.getAltitude(), 0);
+        }
+    }
+
+}

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/dem/FloatAsIsValueExtractorTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/dem/FloatAsIsValueExtractorTest.java
@@ -1,0 +1,43 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+public class FloatAsIsValueExtractorTest {
+
+    @Test
+    public void testScaleOffset() {
+        float noData = -9999.9f;
+        FloatAsIsValueExtractor e = new FloatAsIsValueExtractor(noData);
+
+        double z0 = 3527.125;
+        double z1 = -534.375;
+
+        int tileWidth = 256;
+        int tileHeight = 256;
+        float[] tile = new float[tileWidth * tileHeight];
+        TIFFReader tiffReader = mock(TIFFReader.class);
+        when(tiffReader.readTile(anyInt(), anyInt(), any(float[].class))).thenReturn(tile);
+
+        tile[0] = (float) z0;
+        tile[1] = (float) z1;
+        tile[2] = noData;
+
+        IFD ifd = mock(IFD.class);
+        when(ifd.getTileWidth()).thenReturn(tileWidth);
+        when(ifd.getTileHeight()).thenReturn(tileHeight);
+
+        assertEquals(z0, e.getTileValue(tiffReader, ifd, 0, 0, 0), 0);
+        assertEquals(z1, e.getTileValue(tiffReader, ifd, 0, 0, 1), 0);
+        assertTrue(Double.isNaN(e.getTileValue(tiffReader, ifd, 0, 0, 2)));
+    }
+
+}

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/dem/ScaledGrayscaleValueExtractorTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/dem/ScaledGrayscaleValueExtractorTest.java
@@ -1,0 +1,45 @@
+package fi.nls.oskari.terrainprofile.dem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.oskari.wcs.geotiff.IFD;
+import org.oskari.wcs.geotiff.TIFFReader;
+
+public class ScaledGrayscaleValueExtractorTest {
+
+    @Test
+    public void testScaleOffset() {
+        double scale = 32.0;
+        double offset = -1000;
+        int noData = 0;
+        ScaledGrayscaleValueExtractor e = new ScaledGrayscaleValueExtractor(scale, offset, noData);
+
+        double z0 = 527.125;
+        double z1 = -425.375;
+
+        int tileWidth = 256;
+        int tileHeight = 256;
+        short[] tile = new short[tileWidth * tileHeight];
+        TIFFReader tiffReader = mock(TIFFReader.class);
+        when(tiffReader.readTile(anyInt(), anyInt(), any(short[].class))).thenReturn(tile);
+
+        tile[0] = (short) Math.round(z0 * scale + offset);
+        tile[1] = (short) Math.round(z1 * scale + offset);
+        tile[2] = (short) noData;
+
+        IFD ifd = mock(IFD.class);
+        when(ifd.getTileWidth()).thenReturn(tileWidth);
+        when(ifd.getTileHeight()).thenReturn(tileHeight);
+
+        assertEquals(z0, e.getTileValue(tiffReader, ifd, 0, 0, 0), 0);
+        assertEquals(z1, e.getTileValue(tiffReader, ifd, 0, 0, 1), 0);
+        assertTrue(Double.isNaN(e.getTileValue(tiffReader, ifd, 0, 0, 2)));
+    }
+
+}


### PR DESCRIPTION
Goal is to make
```
<groupId>fi.nls.paikkatietoikkuna</groupId>
<artifactId>service-terrain-profile</artifactId>
<version>1.21.0-SNAPSHOT</version>
```
available as a dependency for other applications (besides Paikkatietoikkuna) by publishing it under Oskari.org repository as
```
<groupId>fi.nls.oskari.extras</groupId>
<artifactId>service-terrain-profile</artifactId>
<version>1.0</version>
```