### PR TITLE
Allow passing apikey to requests

### DIFF
--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>service-terrain-profile</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Terrain Profile</name>
 

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/CommandGetCoverage.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/CommandGetCoverage.java
@@ -3,6 +3,7 @@ package fi.nls.oskari.terrainprofile;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
@@ -10,6 +11,7 @@ import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
 
+import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 
@@ -27,9 +29,18 @@ public class CommandGetCoverage extends HystrixCommand<byte[]> {
     private static final int MAX_RETRIES = 5;
     private static final int SLEEP_BETWEEN_RETRY_MS = 100;
 
-    private final String request;
+    private final Supplier<HttpURLConnection> connectionSupplier;
 
     public CommandGetCoverage(String request) {
+        this(() -> {
+            try {
+                return IOHelper.getConnection(request);
+            } catch (IOException e) {
+                throw new ServiceRuntimeException("Error connecting to service", e);
+            }
+        });
+    }
+    public CommandGetCoverage(Supplier<HttpURLConnection> connectionSupplier) {
         super(Setter
                 .withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY))
                 .andCommandKey(HystrixCommandKey.Factory.asKey(COMMAND_NAME))
@@ -44,12 +55,23 @@ public class CommandGetCoverage extends HystrixCommand<byte[]> {
                         .withCircuitBreakerRequestVolumeThreshold(PropertyUtil.getOptional(GROUP_KEY + ".failrequests", 10))
                         .withCircuitBreakerSleepWindowInMilliseconds(PropertyUtil.getOptional(GROUP_KEY + ".sleepwindow", 10000)))
                 );
-        this.request = request;
+        this.connectionSupplier = connectionSupplier;
+    }
+
+    private HttpURLConnection getConnection() throws IOException {
+        try {
+            return connectionSupplier.get();
+        } catch (ServiceRuntimeException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw e;
+        }
     }
 
     @Override
     protected byte[] run() throws TimeoutException, IOException, Exception {
-        HttpURLConnection conn = IOHelper.getConnection(request);
+        HttpURLConnection conn = getConnection();
         int sc = conn.getResponseCode();
 
         int tryCounter = 0;
@@ -58,7 +80,7 @@ public class CommandGetCoverage extends HystrixCommand<byte[]> {
                 throw new TimeoutException();
             }
             Thread.sleep(SLEEP_BETWEEN_RETRY_MS);
-            conn = IOHelper.getConnection(request);
+            conn = getConnection();
             sc = conn.getResponseCode();
         }
 

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
@@ -42,6 +42,7 @@ public class TerrainProfileHandler extends ActionHandler {
     protected static final String PROPERTY_ENDPOINT = "terrain.profile.wcs.endPoint";
     protected static final String PROPERTY_ENDPOINT_SRS = "terrain.profile.wcs.srs";
     protected static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
+    protected static final String PROPERTY_DEM_APIKEY = "terrain.profile.wcs.APIkey";
     protected static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
     protected static final String PROPERTY_DEM_TYPE = "terrain.profile.wcs.demType";
     protected static final String PROPERTY_DEM_SCALE = "terrain.profile.wcs.demScale";
@@ -88,6 +89,7 @@ public class TerrainProfileHandler extends ActionHandler {
             tps = new TerrainProfileService(
                     PropertyUtil.getNecessary(PROPERTY_ENDPOINT),
                     PropertyUtil.getNecessary(PROPERTY_DEM_COVERAGE_ID),
+                    PropertyUtil.getOptional(PROPERTY_DEM_APIKEY),
                     getTileValueExtractor());
         }
         return tps;


### PR DESCRIPTION
The new API requires this:
```
terrain.profile.wcs.endPoint=https://avoin-karttakuva.maanmittauslaitos.fi/ortokuvat-ja-korkeusmallit/wcs/v2
terrain.profile.wcs.demCoverageId=korkeusmalli_2m
terrain.profile.wcs.noData=-9999.0
terrain.profile.wcs.APIkey=[API key from omatili.maanmittauslaitos.fi]
```

Note! There are some additional tuning required for this as the TIFF in response is not tiled.