### PR TITLE
Request tiled TIFFs for terrain profile

### DIFF
--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>service-terrain-profile</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
     <name>Terrain Profile</name>
 

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
@@ -52,6 +52,7 @@ public class TerrainProfileService {
             0.015625,
             0.0078125
     };
+    private static final String[] TILING_PARAM = new String[] {"true"};
     // password is always empty string with apikey
     private static final String PASSWORD = "";
     private static final int MAX_REDIRECTS = 5;
@@ -332,6 +333,7 @@ public class TerrainProfileService {
         getCoverage.subset("N", northMin, northMax);
         getCoverage.scaling(new ScaleByFactor(scaleFactor));
         Map<String, String[]> getCoverageKVP = getCoverage.toKVP();
+        getCoverageKVP.put("tiling", TILING_PARAM);
 
         String queryString = IOHelper.getParamsMultiValue(getCoverageKVP);
         String request = IOHelper.addQueryString(endPoint, queryString);


### PR DESCRIPTION
As tiled TIFF is what the code supports. The other change required for using the v2 version of terrain profile API. With #21 the version 1.2 of this module now supports https://avoin-karttakuva.maanmittauslaitos.fi/ortokuvat-ja-korkeusmallit/wcs/v2