### PR TITLE
Terrain Profile: handle coordinate transforms between client and backing service

### DIFF
--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>service-terrain-profile</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
     <name>Terrain Profile</name>
 


### PR DESCRIPTION
Currently the input is transformed using service SRS as input and target as output. This fixes the issue by transforming input and reversing transform for output.

Releasing this as version 1.3