### PR TITLE
Fix reverse geocoding buffer issue

### DIFF
--- a/service-search-nls/pom.xml
+++ b/service-search-nls/pom.xml
@@ -5,16 +5,16 @@
 
     <groupId>fi.nls.oskari.extras</groupId>
     <artifactId>oskari-search-nls</artifactId>
-    <version>4.1</version>
+    <version>4.2</version>
     <packaging>jar</packaging>
     <name>NLS Search Service</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
-        <!-- Any version after 2.0.1 as it changed lon/lat on searches from string to double -->
-        <oskari.version>[2.9.0,)</oskari.version>
-        <geotools.version>27.1</geotools.version>
+        <!-- Any version after 2.11.0 uses the same geotools version -->
+        <oskari.version>[2.11.0,)</oskari.version>
+        <geotools.version>28.4</geotools.version>
         <vecmath.version>1.5.2</vecmath.version>
     </properties>
 

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -153,9 +153,11 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
 
         params.put("point.lon", p.getLonToString());
         params.put("point.lat", p.getLatToString());
-
-        params.put("boundary.circle.radius",
-                "" + criteria.getParams().getOrDefault(PARAM_BUFFER, defaultReverseBoundary));
+        String requestedBuffer = criteria.getParamAsString(PARAM_BUFFER);
+        if (requestedBuffer == null) {
+            requestedBuffer = defaultReverseBoundary;
+        }
+        params.put("boundary.circle.radius", requestedBuffer);
         String url = getUrl("reverse", params);
         try {
             HttpURLConnection conn = connectToService(url);

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -155,7 +155,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         params.put("point.lat", p.getLatToString());
 
         params.put("boundary.circle.radius",
-                (String) criteria.getParams().getOrDefault(PARAM_BUFFER, defaultReverseBoundary));
+                "" + criteria.getParams().getOrDefault(PARAM_BUFFER, defaultReverseBoundary));
         String url = getUrl("reverse", params);
         try {
             HttpURLConnection conn = connectToService(url);

--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSNearestFeatureSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSNearestFeatureSearchChannel.java
@@ -43,10 +43,15 @@ public class NLSNearestFeatureSearchChannel extends NLSFIGeocodingSearchChannel 
     }
 
     public String getBuffer(Object param) {
-        if(param != null && param instanceof String) {
-            String str = (String) param;
-            if(!str.isEmpty()) {
-                return str;
+        if (param != null) {
+            if (param instanceof String) {
+                String str = (String) param;
+                if (!str.isEmpty()) {
+                    return str;
+                }
+            } else if (param instanceof Integer) {
+                // fixes issue where GetReverseGeocoding sends default buffer as int
+                return param.toString();
             }
         }
         return "1000";


### PR DESCRIPTION
GetReverseGeocoding in Oskari passes requested (or default) buffer as int. There's a couple of problems with current code:
1) NLSFIGeocodingSearchChannel assumes the buffer is a string which is not always the case -> can result in class cast exception
2) When NLSNearestFeatureSearchChannel is queried it modifies the buffer value for ALL channels. Mostly defaulting it to "1000".

This solves the issue so NLSNearestFeatureSearchChannel doesn't modify the value if it's an integer and NLSFIGeocodingSearchChannel now handles the buffer in a way that shouldn't result in stacktraces in logs.

To be released as version 4.2