### PR TITLE
Fallback to label:kuntatunnus for region

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -217,8 +217,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         // all features seems to have label, geonames have "name" that is an object
         //item.setLocationName((String) feat.properties.get("label"));
         item.setTitle(feat.getString("label"));
-        // "label:municipality" is atleast in both "source" : "geographic-names" && "addresses"
-        item.setRegion(feat.getString("label:municipality"));
+        item.setRegion(getRegion(feat));
         String src = feat.getString("source");
         if (src == null) {
             // all features seems to have label, geonames have "name" that is an object
@@ -253,6 +252,16 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
             }
         }
         return item;
+    }
+
+    static String getRegion(Feature feat) {
+        // "label:municipality" is atleast in both "source" : "geographic-names" && "addresses"
+        String municipality = feat.getString("label:municipality");
+        if (municipality == null) {
+            // label:municipality is missing for source interpolated-road-addresses if and only if lang != fi
+            municipality = feat.getString("label:kuntatunnus");
+        }
+        return municipality;
     }
 
     protected String searchForAddressValue(Feature feat, String propName, String lang) {

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
@@ -93,4 +93,12 @@ public class NLSFIGeocodingSearchChannelTest {
         assertEquals(channel.searchForAddressValue(results.get(1), "katunimi", "asdf"), "Lansankallionkuja");
         //results.stream().forEach(feat -> System.out.println(feat.id));
     }
+
+    @Test
+    public void testResponseParsingForInterpolatedRoadAddressesEn() throws IOException {
+        Map<String, Object> geojson = GeocodeHelper.readJSON(this.getClass().getResourceAsStream("nlsfi-geocoding-search-response-interpolated-road-addresses.json"));
+        List<Feature> results = GeocodeHelper.parseResponse(geojson);
+        assertEquals(2, results.size(), "Should get 2 results");
+        assertEquals("Limingo", NLSFIGeocodingSearchChannel.getRegion(results.get(0)));
+    }
 }

--- a/service-search-nls/src/test/resources/fi/nls/oskari/search/nlsfi-geocoding-search-response-interpolated-road-addresses.json
+++ b/service-search-nls/src/test/resources/fi/nls/oskari/search/nlsfi-geocoding-search-response-interpolated-road-addresses.json
@@ -1,0 +1,104 @@
+{
+  "type" : "FeatureCollection",
+  "features" : [ {
+    "type" : "Feature",
+    "properties" : {
+      "katunimi" : "Perunatie",
+      "katunumero" : "0",
+      "kieli" : "fin",
+      "jarjestysnumero" : 1,
+      "kuntatunnus" : "425",
+      "source" : "interpolated-road-addresses",
+      "gid" : "nlsfi:interpolated-road-addresses#1",
+      "distance" : null,
+      "rank" : 0,
+      "country" : "Finland",
+      "country_gid" : "whosonfirst:country:85633143",
+      "continent" : "Europe",
+      "continent_gid" : "whosonfirst:continent:102191581",
+      "country_a" : "FIN",
+      "label" : "Perunatie (Limingo Liminka)",
+      "municipality" : "425",
+      "label:kuntatunnus" : "Limingo",
+      "match_type" : "interpolated",
+      "accuracy" : "point",
+      "kuntanimiFin" : "Liminka",
+      "kuntanimiSwe" : "Limingo"
+    },
+    "geometry" : {
+      "type" : "Point",
+      "coordinates" : [ 25.413808742112565, 64.79765634310661 ]
+    }
+  }, {
+    "type" : "Feature",
+    "properties" : {
+      "katunimi" : "Perunatie",
+      "katunumero" : "1",
+      "kieli" : "fin",
+      "jarjestysnumero" : 1,
+      "kuntatunnus" : "109",
+      "source" : "interpolated-road-addresses",
+      "gid" : "nlsfi:interpolated-road-addresses#2",
+      "distance" : null,
+      "rank" : 0,
+      "country" : "Finland",
+      "country_gid" : "whosonfirst:country:85633143",
+      "continent" : "Europe",
+      "continent_gid" : "whosonfirst:continent:102191581",
+      "country_a" : "FIN",
+      "label" : "Perunatie 1 (Tavastehus Hämeenlinna)",
+      "municipality" : "109",
+      "label:kuntatunnus" : "Tavastehus",
+      "match_type" : "interpolated",
+      "accuracy" : "point",
+      "kuntanimiFin" : "Hämeenlinna",
+      "kuntanimiSwe" : "Tavastehus"
+    },
+    "geometry" : {
+      "type" : "Point",
+      "coordinates" : [ 24.30079523310849, 60.90099244249881 ]
+    }
+  } ],
+  "geocoding" : {
+    "status" : "success",
+    "metadata" : [ {
+      "rawTerm" : "perunatie",
+      "searchTerm" : "perunatie",
+      "searchTermParts" : [ "perunatie" ],
+      "seartchTermPartCount" : 1,
+      "matchedParts" : [ ],
+      "matchingCodelists" : { },
+      "similarTerms" : [ ]
+    } ],
+    "sources" : {
+      "interpolated-road-addresses" : {
+        "status" : "success",
+        "duration" : 30,
+        "links" : [ ]
+      },
+      "geographic-names" : {
+        "status" : "success",
+        "duration" : 2,
+        "links" : [ ]
+      }
+    },
+    "query" : {
+      "sources" : "geographic-names,addresses,interpolated-road-addresses,cadastral-units,mapsheets-tm35",
+      "scaleDenominator" : 5000,
+      "sortBy" : "placeTypeGroup",
+      "excludesMaps" : { },
+      "text" : "Perunatie",
+      "querySize" : 10,
+      "crs" : "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+      "requestCrs" : "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    },
+    "version" : "2",
+    "attribution" : "https://www.maanmittauslaitos.fi/en/opendata-licence-cc40",
+    "engine" : {
+      "name" : "maanmittauslaitos.fi/geocoding",
+      "author" : "National Land Survey of Finland",
+      "version" : "2"
+    },
+    "timestamp" : 1760089458106
+  }
+}


### PR DESCRIPTION
source `interpolated-road-addresses` doesn't return municipality in `label:municipality` if language is not `fi`.