### PR TITLE
NLSFIGeocodingSearchChannel: contentURL for geographic-names

### DIFF
--- a/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
+++ b/service-search-nls/src/main/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannel.java
@@ -54,6 +54,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
 
     private String baseURL;
     private String apiKey;
+    private String placenamesContentURL;
 
     public Capabilities getCapabilities() {
         return Capabilities.BOTH;
@@ -78,6 +79,7 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         }
         defaultSources = getProperty("sources", defaultSources);
         defaultReverseBoundary = getProperty("reverse.boundary", defaultReverseBoundary);
+        placenamesContentURL = getProperty("placenames.contenturl", null);
         // defaults
         //endPoints.put("default", "/v1/pelias/search"); // the text search
         endPoints.put("default", "/v2/advanced/search"); // the text search
@@ -207,12 +209,11 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         return result;
     }
 
-    private SearchResultItem getItem(Feature feat, String lang) {
+    SearchResultItem getItem(Feature feat, String lang) {
 
         SearchResultItem item = new SearchResultItem();
         item.setLat(feat.y);
         item.setLon(feat.x);
-        item.setContentURL(feat.x + "_" + feat.y);
 
         // all features seems to have label, geonames have "name" that is an object
         //item.setLocationName((String) feat.properties.get("label"));
@@ -229,8 +230,11 @@ public class NLSFIGeocodingSearchChannel extends SearchChannel implements Search
         item.setType(src);
 
         if ("geographic-names".equals(src)) {
-            // all features seems to have label, geonames have "name" that is an object
-            item.setResourceId("" + feat.properties.get("placeId"));
+            Object placeId = feat.properties.get("placeId");
+            item.setResourceId("" + placeId);
+            if (placenamesContentURL != null && placeId != null) {
+                item.setContentURL(placenamesContentURL + placeId);
+            }
             Integer scaleRelevance = (Integer)feat.properties.get("scaleRelevance");
             if (scaleRelevance != null && scaleRelevance > 0) {
                 // divide by to get a closer zoom. Oskari zooms out to get the scale

--- a/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
+++ b/service-search-nls/src/test/java/fi/nls/oskari/search/NLSFIGeocodingSearchChannelTest.java
@@ -1,5 +1,6 @@
 package fi.nls.oskari.search;
 
+import fi.mml.portti.service.search.SearchResultItem;
 import fi.nls.oskari.search.geocoding.Feature;
 import fi.nls.oskari.search.geocoding.GeocodeHelper;
 import fi.nls.oskari.service.ServiceRuntimeException;
@@ -30,6 +31,7 @@ public class NLSFIGeocodingSearchChannelTest {
         String user = "[this is an api key for testing]"; //apikey
         PropertyUtil.addProperty("search.channel." + NLSFIGeocodingSearchChannel.ID + ".APIkey", user);
         PropertyUtil.addProperty("search.channel." + NLSFIGeocodingSearchChannel.ID + ".endpoint.test", "/xyz/testing");
+        PropertyUtil.addProperty("search.channel." + NLSFIGeocodingSearchChannel.ID + ".placenames.contenturl", "https://tietokortit.maanmittauslaitos.fi/nimisto/paikka/");
         channel.init();
     }
 
@@ -81,6 +83,22 @@ public class NLSFIGeocodingSearchChannelTest {
         assertEquals(5, results.size(), "Should get 5 results");
         assertEquals(channel.searchForAddressValue(results.get(0), "katunimi", "fi"), "Repovuorentie");
         //results.stream().forEach(feat -> System.out.println(feat.id));
+    }
+
+    @Test
+    public void testGeonamesItemHasContentURL() throws IOException {
+        Map<String, Object> geojson = GeocodeHelper.readJSON(this.getClass().getResourceAsStream("nlsfi-geocoding-search-response-geonames.json"));
+        List<Feature> results = GeocodeHelper.parseResponse(geojson);
+        SearchResultItem item = channel.getItem(results.get(0), "fi");
+        assertEquals("https://tietokortit.maanmittauslaitos.fi/nimisto/paikka/10581718", item.getContentURL());
+    }
+
+    @Test
+    public void testAddressItemHasNoContentURL() throws IOException {
+        Map<String, Object> geojson = GeocodeHelper.readJSON(this.getClass().getResourceAsStream("nlsfi-geocoding-search-response-addresses.json"));
+        List<Feature> results = GeocodeHelper.parseResponse(geojson);
+        SearchResultItem item = channel.getItem(results.get(0), "fi");
+        assertNull(item.getContentURL());
     }
 
     @Test


### PR DESCRIPTION
Add contentURL for items from source geographic-names. Base URL is configured via properties. If not configured then contentURL is not set. Additionally, remove current behaviour of setting contentURL to `"{x}_{y}"`.

Configuration example:
```
search.channel.NLSFI_GEOCODING.placenames.contenturl=https://tietokortit.maanmittauslaitos.fi/nimisto/paikka/
```
This is just a dumb prefix, so trailing slash is not optional