### PR TITLE
Add TerrainElevationSearchChannel

### DIFF
--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -49,6 +49,18 @@
         </dependency>
         <dependency>
             <groupId>org.oskari</groupId>
+            <artifactId>service-search</artifactId>
+            <version>${oskari.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>service-map</artifactId>
+            <version>${oskari.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
             <artifactId>shared-test-resources</artifactId>
             <version>${oskari.version}</version>
             <scope>test</scope>

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainElevationSearchChannel.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainElevationSearchChannel.java
@@ -1,0 +1,110 @@
+package fi.nls.oskari.terrainprofile;
+
+import fi.mml.portti.service.search.ChannelSearchResult;
+import fi.mml.portti.service.search.SearchCriteria;
+import fi.mml.portti.service.search.SearchResultItem;
+import fi.nls.oskari.annotation.Oskari;
+import fi.nls.oskari.domain.geo.Point;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.geometry.ProjectionHelper;
+import fi.nls.oskari.search.channel.SearchChannel;
+import fi.nls.oskari.service.ServiceException;
+
+import java.util.List;
+
+/**
+ * Search channel for resolving the terrain elevation (altitude) of a single point via "reverse geocoding".
+ */
+@Oskari(TerrainElevationSearchChannel.ID)
+public class TerrainElevationSearchChannel extends SearchChannel {
+
+    public static final String ID = "TerrainElevationSearchChannel";
+
+    private static final Logger LOG = LogFactory.getLogger(TerrainElevationSearchChannel.class);
+
+    private TerrainProfileService tps;
+
+    public TerrainElevationSearchChannel() {
+        this(null);
+    }
+
+    public TerrainElevationSearchChannel(TerrainProfileService tps) {
+        this.tps = tps;
+    }
+
+    @Override
+    public void init() {
+        super.init();
+        try {
+            getService();
+        } catch (ServiceException e) {
+            // not fatal, try again later when a request comes in
+            LOG.error("Failed to init TerrainProfileService: " + e.getMessage(), e);
+        }
+    }
+
+    protected synchronized TerrainProfileService getService() throws ServiceException {
+        if (tps == null) {
+            tps = TerrainProfileService.fromProperties();
+        }
+        return tps;
+    }
+
+    // Only reverse geocoding is supported
+    @Override
+    public Capabilities getCapabilities() {
+        return Capabilities.COORD;
+    }
+
+    @Override
+    public boolean isValidSearchTerm(SearchCriteria criteria) {
+        return criteria.isReverseGeocode();
+    }
+
+    @Override
+    public ChannelSearchResult reverseGeocode(SearchCriteria criteria) {
+        ChannelSearchResult result = new ChannelSearchResult();
+        result.setChannelId(ID);
+
+        final double lon = criteria.getLon();
+        final double lat = criteria.getLat();
+        final String srs = criteria.getSRS();
+
+        try {
+            TerrainProfileService service = getService();
+            double e = lon;
+            double n = lat;
+            String serviceSrs = service.getServiceSrs();
+            // only reproject to the DEM's coordinate system if the queried point isn't already in it
+            if (srs != null && !srs.equalsIgnoreCase(serviceSrs)) {
+                Point p = ProjectionHelper.transformPoint(lon, lat, srs, serviceSrs);
+                e = p.getLon();
+                n = p.getLat();
+            }
+            List<DataPoint> points = service.getTerrainProfile(new double[] { e, n }, 1, 0);
+            if (points.isEmpty()) {
+                return result;
+            }
+            double altitude = points.get(0).getAltitude();
+            if (Double.isNaN(altitude)) {
+                // no elevation data at this point
+                return result;
+            }
+
+            SearchResultItem item = new SearchResultItem();
+            // echo the queried coordinates back in the requested SRS
+            item.setLon(lon);
+            item.setLat(lat);
+            item.setType(ID);
+            item.setTitle(Double.toString(altitude));
+            item.addValue("altitude", altitude);
+            result.addItem(item);
+        } catch (Exception ex) {
+            LOG.error("Couldn't get terrain elevation from service", ex.getMessage());
+            result.setQueryFailed(true);
+        }
+
+        return result;
+    }
+}

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileHandler.java
@@ -11,9 +11,6 @@ import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceRuntimeException;
-import fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor;
-import fi.nls.oskari.terrainprofile.dem.ScaledGrayscaleValueExtractor;
-import fi.nls.oskari.terrainprofile.dem.TileValueExtractor;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
@@ -23,8 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.geotools.referencing.CRS;
 import org.geotools.api.referencing.FactoryException;
@@ -40,15 +35,6 @@ public class TerrainProfileHandler extends ActionHandler {
 
     protected static final String PARAM_ROUTE = "route";
 
-    protected static final String PROPERTY_ENDPOINT = "terrain.profile.wcs.endPoint";
-    protected static final String PROPERTY_ENDPOINT_SRS = "terrain.profile.wcs.srs";
-    protected static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
-    protected static final String PROPERTY_DEM_APIKEY = "terrain.profile.wcs.APIkey";
-    protected static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
-    protected static final String PROPERTY_DEM_TYPE = "terrain.profile.wcs.demType";
-    protected static final String PROPERTY_DEM_SCALE = "terrain.profile.wcs.demScale";
-    protected static final String PROPERTY_DEM_OFFSET = "terrain.profile.wcs.demOffset";
-
     protected static final String JSON_PROPERTY_PROPERTIES = "properties";
     protected static final String JSON_PROPERTY_NUM_POINTS = "numPoints";
     protected static final String JSON_PROPERTY_SCALE_FACTOR = "scaleFactor";
@@ -59,7 +45,6 @@ public class TerrainProfileHandler extends ActionHandler {
 
     private final ObjectMapper om;
     private TerrainProfileService tps;
-    private String serviceSrs;
 
     public TerrainProfileHandler() {
         this(new ObjectMapper(), null);
@@ -82,49 +67,13 @@ public class TerrainProfileHandler extends ActionHandler {
             // not fatal, proceed with init and try again later
             LOG.error("Failed to init TerrainProfileService: " + ex.getMessage(), ex);
         }
-        serviceSrs = PropertyUtil.get(PROPERTY_ENDPOINT_SRS, DEFAULT_SRS).toUpperCase();
     }
 
     protected synchronized TerrainProfileService getService() throws ServiceException {
         if (tps == null) {
-            tps = new TerrainProfileService(
-                    PropertyUtil.getNecessary(PROPERTY_ENDPOINT),
-                    PropertyUtil.getNecessary(PROPERTY_DEM_COVERAGE_ID),
-                    PropertyUtil.getOptional(PROPERTY_DEM_APIKEY),
-                    getTileValueExtractor());
+            tps = TerrainProfileService.fromProperties();
         }
         return tps;
-    }
-
-    private Supplier<TileValueExtractor> getTileValueExtractor() {
-        String type = PropertyUtil.get(PROPERTY_DEM_TYPE, FloatAsIsValueExtractor.ID);
-
-        switch (type) {
-        case ScaledGrayscaleValueExtractor.ID:
-            double scale = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_SCALE));
-            double offset = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_OFFSET));
-            short noDataS = getNoDataValue(Short::parseShort).shortValue();
-            return () -> new ScaledGrayscaleValueExtractor(scale, offset, noDataS);
-
-        case FloatAsIsValueExtractor.ID:
-        default:
-            float noDataF = getNoDataValue(Float::parseFloat).floatValue();
-            return () -> new FloatAsIsValueExtractor(noDataF);
-        }
-    }
-
-    private Number getNoDataValue(Function<String, Number> parser) {
-        String noDataStr = PropertyUtil.getOptional(PROPERTY_NODATA_VALUE);
-        if (noDataStr != null && !noDataStr.isEmpty()) {
-            try {
-                Number noDataValue = parser.apply(noDataStr);
-                LOG.debug("NODATA value:", noDataValue);
-                return noDataValue;
-            } catch (NumberFormatException e) {
-                LOG.warn("Could not parse NODATA value from " + noDataStr);
-            }
-        }
-        return Double.NaN;
     }
 
     @Override
@@ -138,8 +87,15 @@ public class TerrainProfileHandler extends ActionHandler {
         // Allow route to be GC'd
         route = null;
 
+        TerrainProfileService service;
+        try {
+            service = getService();
+        } catch (ServiceException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+
         String clientSRS = params.getHttpParam(ActionConstants.PARAM_SRS, DEFAULT_SRS);
-        MathTransform transform = getTransform(clientSRS, serviceSrs);
+        MathTransform transform = getTransform(clientSRS, service.getServiceSrs());
 
         if (transform != null) {
             transformInPlace(points, transform);
@@ -151,7 +107,7 @@ public class TerrainProfileHandler extends ActionHandler {
         }
 
         try {
-            List<DataPoint> dp = getService().getTerrainProfile(points, numPoints, scaleFactor);
+            List<DataPoint> dp = service.getTerrainProfile(points, numPoints, scaleFactor);
             if (transform != null) {
                 // we transformed input so we must transform for output by inversing input/output srs
                 transformInPlace(dp, transform.inverse());

--- a/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
+++ b/service-terrain-profile/src/main/java/fi/nls/oskari/terrainprofile/TerrainProfileService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -15,8 +16,10 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor;
+import fi.nls.oskari.terrainprofile.dem.ScaledGrayscaleValueExtractor;
 import fi.nls.oskari.terrainprofile.dem.TileValueExtractor;
 import fi.nls.oskari.terrainprofile.dem.TiledTiffDEM;
+import fi.nls.oskari.util.PropertyUtil;
 import org.oskari.wcs.capabilities.Capabilities;
 import org.oskari.wcs.coverage.CoverageDescription;
 import org.oskari.wcs.coverage.RectifiedGridCoverage;
@@ -64,6 +67,63 @@ public class TerrainProfileService {
     private final double originNorth;
     private final double offsetVectorX;
     private final double offsetVectorY;
+    private String serviceSrs = DEFAULT_SRS;
+
+    public static final String DEFAULT_SRS = "EPSG:3067";
+
+    public static final String PROPERTY_ENDPOINT = "terrain.profile.wcs.endPoint";
+    public static final String PROPERTY_ENDPOINT_SRS = "terrain.profile.wcs.srs";
+    public static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
+    public static final String PROPERTY_DEM_APIKEY = "terrain.profile.wcs.APIkey";
+    public static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
+    public static final String PROPERTY_DEM_TYPE = "terrain.profile.wcs.demType";
+    public static final String PROPERTY_DEM_SCALE = "terrain.profile.wcs.demScale";
+    public static final String PROPERTY_DEM_OFFSET = "terrain.profile.wcs.demOffset";
+
+    /**
+     * Build a service from the shared terrain.profile.wcs.* properties.
+     * Used by both TerrainProfileHandler and search channels.
+     */
+    public static TerrainProfileService fromProperties() throws ServiceException {
+        TerrainProfileService service = new TerrainProfileService(
+                PropertyUtil.getNecessary(PROPERTY_ENDPOINT),
+                PropertyUtil.getNecessary(PROPERTY_DEM_COVERAGE_ID),
+                PropertyUtil.getOptional(PROPERTY_DEM_APIKEY),
+                getTileValueExtractor());
+        service.serviceSrs = PropertyUtil.get(PROPERTY_ENDPOINT_SRS, DEFAULT_SRS).toUpperCase();
+        return service;
+    }
+
+
+
+    private static Supplier<TileValueExtractor> getTileValueExtractor() {
+        String type = PropertyUtil.get(PROPERTY_DEM_TYPE, FloatAsIsValueExtractor.ID);
+
+        switch (type) {
+        case ScaledGrayscaleValueExtractor.ID:
+            double scale = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_SCALE));
+            double offset = Double.parseDouble(PropertyUtil.getNecessary(PROPERTY_DEM_OFFSET));
+            short noDataS = getNoDataValue(Short::parseShort).shortValue();
+            return () -> new ScaledGrayscaleValueExtractor(scale, offset, noDataS);
+
+        case FloatAsIsValueExtractor.ID:
+        default:
+            float noDataF = getNoDataValue(Float::parseFloat).floatValue();
+            return () -> new FloatAsIsValueExtractor(noDataF);
+        }
+    }
+
+    private static Number getNoDataValue(Function<String, Number> parser) {
+        String noDataStr = PropertyUtil.getOptional(PROPERTY_NODATA_VALUE);
+        if (noDataStr != null && !noDataStr.isEmpty()) {
+            try {
+                return parser.apply(noDataStr);
+            } catch (NumberFormatException e) {
+                // fall through to NaN
+            }
+        }
+        return Double.NaN;
+    }
 
     public TerrainProfileService(String endPoint, String coverageId) throws ServiceException {
         this(endPoint, coverageId, () -> new FloatAsIsValueExtractor(Float.NaN));
@@ -93,6 +153,10 @@ public class TerrainProfileService {
         } catch (IOException | ParserConfigurationException | SAXException e) {
             throw new ServiceException("Failed to initialize", e);
         }
+    }
+
+    public String getServiceSrs() {
+        return serviceSrs;
     }
 
     private Capabilities getCapabilities(String endPoint)

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileHandlerTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileHandlerTest.java
@@ -177,9 +177,14 @@ public class TerrainProfileHandlerTest {
         params.setRequest(request);
         params.setResponse(response);
 
-        String endPoint = "https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows";
-        String coverageId = "korkeusmalli__korkeusmalli";
-        TerrainProfileService tps = new TerrainProfileService(endPoint, coverageId);
+        // Configurable so the live endpoint/coverage/apikey aren't baked into the repo.
+        // Run with e.g. -Dterrain.test.apikey=... when enabling.
+        String endPoint = System.getProperty("terrain.test.endpoint",
+                "https://avoin-karttakuva.maanmittauslaitos.fi/ortokuvat-ja-korkeusmallit/wcs/v2");
+        String coverageId = System.getProperty("terrain.test.coverage", "korkeusmalli_2m");
+        String apiKey = System.getProperty("terrain.test.apikey");
+        TerrainProfileService tps = new TerrainProfileService(endPoint, coverageId, apiKey,
+                () -> new fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor(Float.NaN));
         new TerrainProfileHandler(om, tps).handleAction(params);
     }
 

--- a/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileServiceTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/oskari/terrainprofile/TerrainProfileServiceTest.java
@@ -18,13 +18,19 @@ import fi.nls.oskari.service.ServiceException;
 @Disabled("Depends on an outside API")
 public class TerrainProfileServiceTest {
 
-    private static String endPoint = "https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows";
-    private static String coverageId = "korkeusmalli__korkeusmalli";
+    // Configurable so the live endpoint/coverage/apikey aren't baked into the repo.
+    // Run with e.g. -Dterrain.test.apikey=... -Dterrain.test.endpoint=... when enabling.
+    private static String endPoint = System.getProperty("terrain.test.endpoint",
+            "https://avoin-karttakuva.maanmittauslaitos.fi/ortokuvat-ja-korkeusmallit/wcs/v2");
+    private static String coverageId = System.getProperty("terrain.test.coverage", "korkeusmalli_2m");
+    private static String apiKey = System.getProperty("terrain.test.apikey");
+    private static float noData = Float.parseFloat(System.getProperty("terrain.test.noData", "-9999"));
     private static TerrainProfileService tps;
 
     @BeforeAll
     public static void setup() throws ServiceException {
-        tps = new TerrainProfileService(endPoint, coverageId);
+        tps = new TerrainProfileService(endPoint, coverageId, apiKey,
+                () -> new fi.nls.oskari.terrainprofile.dem.FloatAsIsValueExtractor(noData)); //
     }
 
     @Test
@@ -47,6 +53,27 @@ public class TerrainProfileServiceTest {
             assertEquals(n, single.getN(), 0.0);
             assertEquals(p.getAltitude(), single.getAltitude(), 0.0);
         }
+    }
+
+    @Test
+    @Disabled("Depends on an outside API")
+    public void singlePointReturnsSensibleValue() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        // a point on land in southern Finland (EPSG:3067) should have a real, positive elevation
+        double e = 385445;
+        double n = 6675125;
+        double alt = tps.getTerrainProfile(new double[] { e, n }, 1, 0).get(0).getAltitude();
+        assertFalse(Double.isNaN(alt), "expected a value, got NaN");
+        assertTrue(alt > 0 && alt < 1500, "elevation out of expected range: " + alt);
+    }
+
+    @Test
+    @Disabled("Depends on an outside API")
+    public void singlePointOutsideCoverageIsNaN() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        // a point in open sea / outside the land DEM should have no elevation data
+        double e = 150000;
+        double n = 6900000;
+        double alt = tps.getTerrainProfile(new double[] { e, n }, 1, 0).get(0).getAltitude();
+        assertTrue(Double.isNaN(alt), "expected NaN for out-of-coverage point, got " + alt);
     }
 
     @Test


### PR DESCRIPTION
Add Search channel resolving terrain altitude for a single point via "reverse geocoding", reusing the WCS DEM backend behind `TerrainProfileHandler`. Move the now common logic initializing `TerrainProfileService` based on properties from `TerrainProfileHandler` directly to `TerrainProfileService`.

Refresh default references to the NLSFI WCS in `@Disabled` tests.